### PR TITLE
Adds Response class and tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME = webserv
 
-FILES = main.cpp Webserv.cpp
+FILES = main.cpp Webserv.cpp Response.cpp
 
 CXX = c++
 CXXFLAGS = -Wall -Wextra -Werror -std=c++98

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -1,0 +1,62 @@
+#include "response.hpp"
+
+namespace Webserv {
+    Response::Response() {
+        initialize_status_messages();
+    }
+
+    void Response::initialize_status_messages() {
+        // Initialize status code and messages
+        status_messages[200] = "OK";
+        status_messages[404] = "Not Found";
+        // Add more status codes and messages as needed
+    }
+
+    void Response::set_header(const std::string& key, const std::string& value) {
+        headers[key] = value;
+    }
+
+    std::string Response::get_header(const std::string& key) const {
+        std::map<std::string, std::string>::const_iterator it = headers.find(key);
+        if (it != headers.end()) {
+            return it->second;
+        } else {
+            return ""; // Return an empty string if key is not found
+        }
+    }
+
+    void Response::set_status(int code) {
+        status_code = code;
+    }
+
+    int Response::get_status_code() const {
+        return status_code;
+    }
+
+    std::string Response::get_status_message(int code) const {
+        std::map<int, std::string>::const_iterator it = status_messages.find(code);
+        if (it != status_messages.end()) {
+            return it->second;
+        } else {
+            return ""; // Return an empty string if code is not found
+        }
+    }
+
+    std::string Response::build_response() const {
+        std::stringstream response;
+        response << "HTTP/1.1 " << status_code << " " << get_status_message(status_code) << "\r\n";
+        for (std::map<std::string, std::string>::const_iterator it = headers.begin(); it != headers.end(); ++it) {
+            response << it->first << ": " << it->second << "\r\n";
+        }
+        response << "\r\n" << body << "\r\n";
+        return response.str();
+    }
+
+    void Response::set_body(const std::string& body) {
+        this->body = body;
+    }
+
+    std::string Response::get_body() const {
+        return body;
+    }
+}

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -2,33 +2,25 @@
 
 namespace Webserv {
     Response::Response() {
-        initialize_status_messages();
-    }
-
-    void Response::initialize_status_messages() {
-        // Initialize status code and messages
+        // Initialize status messages
         status_messages[200] = "OK";
         status_messages[404] = "Not Found";
-        // Add more status codes and messages as needed
+    }
+
+    // -- Setters ---
+    void Response::set_status(int code) {
+        status_code = code;
     }
 
     void Response::set_header(const std::string& key, const std::string& value) {
         headers[key] = value;
     }
 
-    std::string Response::get_header(const std::string& key) const {
-        std::map<std::string, std::string>::const_iterator it = headers.find(key);
-        if (it != headers.end()) {
-            return it->second;
-        } else {
-            return ""; // Return an empty string if key is not found
-        }
+    void Response::set_body(const std::string& body) {
+        this->body = body;
     }
 
-    void Response::set_status(int code) {
-        status_code = code;
-    }
-
+    // --- Getters --- 
     int Response::get_status_code() const {
         return status_code;
     }
@@ -37,26 +29,34 @@ namespace Webserv {
         std::map<int, std::string>::const_iterator it = status_messages.find(code);
         if (it != status_messages.end()) {
             return it->second;
-        } else {
-            return ""; // Return an empty string if code is not found
-        }
+        } 
+        return "";
     }
 
-    std::string Response::build_response() const {
-        std::stringstream response;
-        response << "HTTP/1.1 " << status_code << " " << get_status_message(status_code) << "\r\n";
-        for (std::map<std::string, std::string>::const_iterator it = headers.begin(); it != headers.end(); ++it) {
-            response << it->first << ": " << it->second << "\r\n";
+    std::string Response::get_header(const std::string& key) const {
+        std::map<std::string, std::string>::const_iterator it = headers.find(key);
+        if (it != headers.end()) {
+            return it->second;
         }
-        response << "\r\n" << body << "\r\n";
-        return response.str();
-    }
-
-    void Response::set_body(const std::string& body) {
-        this->body = body;
+        return "";
     }
 
     std::string Response::get_body() const {
         return body;
+    }
+
+    // --- Other methods ---
+    std::string Response::build_response() const {
+        std::stringstream response;
+        // Add status line
+        response << "HTTP/1.1 " << status_code << " " << get_status_message(status_code) << "\r\n";
+        // Add headers
+        for (std::map<std::string, std::string>::const_iterator it = headers.begin(); it != headers.end(); ++it) {
+            response << it->first << ": " << it->second << "\r\n";
+        }
+        // Add body
+        response << "\r\n" << body << "\r\n";
+        // Return response
+        return response.str();
     }
 }

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -1,4 +1,4 @@
-#include "response.hpp"
+#include "Response.hpp"
 
 namespace Webserv {
     Response::Response() {

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -1,15 +1,20 @@
 #include "Response.hpp"
 
+const std::string Webserv::Response::HTTP_VERSION = "HTTP/1.1";
+
 namespace Webserv {
     Response::Response() {
         // Initialize status messages
-        status_messages[200] = "OK";
-        status_messages[404] = "Not Found";
+        reason_phrase[200] = "OK";
+        reason_phrase[404] = "Not Found";
     }
 
     // -- Setters ---
     void Response::set_status(int code) {
-        status_code = code;
+        // Don't allow a status that it not mapped
+        if (reason_phrase.find(code) == reason_phrase.end())
+            throw std::invalid_argument("Invalid status code");
+        this->status_code = code;
     }
 
     void Response::set_header(const std::string& key, const std::string& value) {
@@ -17,20 +22,15 @@ namespace Webserv {
     }
 
     void Response::set_body(const std::string& body) {
+        std::stringstream string_stream;
+        string_stream << body.size();
+        set_header("Content-Length", string_stream.str());
         this->body = body;
     }
 
     // --- Getters --- 
     int Response::get_status_code() const {
         return status_code;
-    }
-
-    std::string Response::get_status_message(int code) const {
-        std::map<int, std::string>::const_iterator it = status_messages.find(code);
-        if (it != status_messages.end()) {
-            return it->second;
-        } 
-        return "";
     }
 
     std::string Response::get_header(const std::string& key) const {
@@ -45,18 +45,19 @@ namespace Webserv {
         return body;
     }
 
-    // --- Other methods ---
     std::string Response::build_response() const {
         std::stringstream response;
-        // Add status line
-        response << "HTTP/1.1 " << status_code << " " << get_status_message(status_code) << "\r\n";
-        // Add headers
+        // Status line
+        response << HTTP_VERSION << " " << status_code << " " << reason_phrase.at(status_code) << "\r\n";
+        // Headers
         for (std::map<std::string, std::string>::const_iterator it = headers.begin(); it != headers.end(); ++it) {
             response << it->first << ": " << it->second << "\r\n";
         }
-        // Add body
-        response << "\r\n" << body << "\r\n";
-        // Return response
+        // Empty line indicating the end of the header section
+        response << "\r\n";
+        // Optional message body
+        if (body.size() > 0)
+            response << body;
         return response.str();
     }
-}
+} 

--- a/src/Response.hpp
+++ b/src/Response.hpp
@@ -7,25 +7,31 @@
 
 namespace Webserv {
     class Response {
-    private:
-        std::map<int, std::string> status_messages;
-        std::map<std::string, std::string> headers;
-        int status_code;
-        std::string body;
-
-        void initialize_status_messages();
-
     public:
+        // Constructor
         Response();
-        void set_header(const std::string& key, const std::string& value);
-        std::string get_header(const std::string& key) const;
+
+        // Setters
         void set_status(int code);
+        void set_header(const std::string& key, const std::string& value);
+        void set_body(const std::string& body);
+
+        // Getters
         int get_status_code() const;
         std::string get_status_message(int code) const;
-        std::string build_response() const;
-        void set_body(const std::string& body);
+        std::string get_header(const std::string& key) const;
         std::string get_body() const;
+
+        // Other methods
+        std::string build_response() const;
+
+    private:
+        // Attributes
+        int status_code;
+        std::map<int, std::string> status_messages;
+        std::map<std::string, std::string> headers;
+        std::string body;
     };
 }
 
-#endif  // RESPONSE_H
+#endif

--- a/src/Response.hpp
+++ b/src/Response.hpp
@@ -1,0 +1,31 @@
+#ifndef RESPONSE_H
+#define RESPONSE_H
+
+#include <map>
+#include <string>
+#include <sstream>
+
+namespace Webserv {
+    class Response {
+    private:
+        std::map<int, std::string> status_messages;
+        std::map<std::string, std::string> headers;
+        int status_code;
+        std::string body;
+
+        void initialize_status_messages();
+
+    public:
+        Response();
+        void set_header(const std::string& key, const std::string& value);
+        std::string get_header(const std::string& key) const;
+        void set_status(int code);
+        int get_status_code() const;
+        std::string get_status_message(int code) const;
+        std::string build_response() const;
+        void set_body(const std::string& body);
+        std::string get_body() const;
+    };
+}
+
+#endif  // RESPONSE_H

--- a/src/Response.hpp
+++ b/src/Response.hpp
@@ -18,17 +18,18 @@ namespace Webserv {
 
         // Getters
         int get_status_code() const;
-        std::string get_status_message(int code) const;
         std::string get_header(const std::string& key) const;
         std::string get_body() const;
 
         // Other methods
         std::string build_response() const;
-
     private:
+        // Constants
+        static const std::string HTTP_VERSION;
+
         // Attributes
         int status_code;
-        std::map<int, std::string> status_messages;
+        std::map<int, std::string> reason_phrase;
         std::map<std::string, std::string> headers;
         std::string body;
     };

--- a/src/Response_test.cpp
+++ b/src/Response_test.cpp
@@ -19,21 +19,18 @@ TEST_CASE("Response test") {
         CHECK_EQ(response.get_status_code(), 200);
     }
 
-    SUBCASE("Getting status message") {
-        CHECK_EQ(response.get_status_message(200), "OK");
-        CHECK_EQ(response.get_status_message(404), "Not Found");
-        CHECK_EQ(response.get_status_message(500), "");
-    }
-
     SUBCASE("Building response") {
         response.set_status(200);
+        response.set_header("Content-Length", "42");
         response.set_header("Content-Type", "text/html");
-        response.set_body("<html><body>Hello, world!</body></html>");
+        response.set_body("<html><body>Hello, world!!!!</body></html>");
 
-        std::string expected_response = "HTTP/1.1 200 OK\r\n"
-                                        "Content-Type: text/html\r\n"
-                                        "\r\n"
-                                        "<html><body>Hello, world!</body></html>\r\n";
+        std::string expected_response = 
+        "HTTP/1.1 200 OK\r\n"
+        "Content-Length: 42\r\n"
+        "Content-Type: text/html\r\n"
+        "\r\n"
+        "<html><body>Hello, world!!!!</body></html>\r\n";
 
         CHECK_EQ(response.build_response(), expected_response);
     }

--- a/src/Response_test.cpp
+++ b/src/Response_test.cpp
@@ -1,0 +1,40 @@
+#include "doctest.h"
+#include "response.hpp"
+
+TEST_CASE("Response test") {
+    Webserv::Response response;
+
+    SUBCASE("Setting and retrieving headers") {
+        response.set_header("Content-Type", "text/html");
+        response.set_header("Content-Length", "42");
+
+        CHECK_EQ(response.get_header("Content-Type"), "text/html");
+        CHECK_EQ(response.get_header("Content-Length"), "42");
+        CHECK_EQ(response.get_header("Unknown-Header"), "");
+    }
+
+    SUBCASE("Setting and retrieving status code") {
+        response.set_status(200);
+
+        CHECK_EQ(response.get_status_code(), 200);
+    }
+
+    SUBCASE("Getting status message") {
+        CHECK_EQ(response.get_status_message(200), "OK");
+        CHECK_EQ(response.get_status_message(404), "Not Found");
+        CHECK_EQ(response.get_status_message(500), "");
+    }
+
+    SUBCASE("Building response") {
+        response.set_status(200);
+        response.set_header("Content-Type", "text/html");
+        response.set_body("<html><body>Hello, world!</body></html>");
+
+        std::string expected_response = "HTTP/1.1 200 OK\r\n"
+                                        "Content-Type: text/html\r\n"
+                                        "\r\n"
+                                        "<html><body>Hello, world!</body></html>\r\n";
+
+        CHECK_EQ(response.build_response(), expected_response);
+    }
+}

--- a/src/Response_test.cpp
+++ b/src/Response_test.cpp
@@ -1,37 +1,43 @@
 #include "doctest.h"
 #include "Response.hpp"
 
-TEST_CASE("Response test") {
+TEST_CASE("Response class") {
     Webserv::Response response;
 
-    SUBCASE("Setting and retrieving headers") {
-        response.set_header("Content-Type", "text/html");
-        response.set_header("Content-Length", "42");
-
-        CHECK_EQ(response.get_header("Content-Type"), "text/html");
-        CHECK_EQ(response.get_header("Content-Length"), "42");
-        CHECK_EQ(response.get_header("Unknown-Header"), "");
-    }
-
-    SUBCASE("Setting and retrieving status code") {
+    SUBCASE("Setters and getters") {
         response.set_status(200);
-
         CHECK_EQ(response.get_status_code(), 200);
+
+        response.set_header("Content-Type", "text/html");
+        CHECK_EQ(response.get_header("Content-Type"), "text/html");
+        CHECK_EQ(response.get_header("Unknown-Header"), "");
+
+        response.set_body("<html><body>Hello, world!</body></html>");
+        CHECK_EQ(response.get_body(), "<html><body>Hello, world!</body></html>");
     }
 
-    SUBCASE("Building response") {
-        response.set_status(200);
-        response.set_header("Content-Length", "42");
-        response.set_header("Content-Type", "text/html");
-        response.set_body("<html><body>Hello, world!!!!</body></html>");
+    SUBCASE("build_response method") {
 
-        std::string expected_response = 
-        "HTTP/1.1 200 OK\r\n"
-        "Content-Length: 42\r\n"
-        "Content-Type: text/html\r\n"
-        "\r\n"
-        "<html><body>Hello, world!!!!</body></html>\r\n";
+        SUBCASE("Status code 404 with no body") {
+            response.set_status(404);
+            std::string expected_response = 
+                "HTTP/1.1 404 Not Found\r\n"
+                "\r\n";
+            CHECK_EQ(response.build_response(), expected_response);
+        }
 
-        CHECK_EQ(response.build_response(), expected_response);
+        SUBCASE("Status code 200 with body") {
+            response.set_status(200);
+            response.set_header("Content-Type", "text/html");
+            response.set_header("Content-Length", "42");
+            response.set_body("<html><body>Hello, world!!!!</body></html>");
+            std::string expected_response = 
+                "HTTP/1.1 200 OK\r\n"
+                "Content-Length: 42\r\n"
+                "Content-Type: text/html\r\n"
+                "\r\n"
+                "<html><body>Hello, world!!!!</body></html>";
+            CHECK_EQ(response.build_response(), expected_response);
+        }
     }
 }

--- a/src/Response_test.cpp
+++ b/src/Response_test.cpp
@@ -1,5 +1,5 @@
 #include "doctest.h"
-#include "response.hpp"
+#include "Response.hpp"
 
 TEST_CASE("Response test") {
     Webserv::Response response;


### PR DESCRIPTION
Follows the `Message` standard defined on RFC 9112 to format the string when using the method `build_response`
https://www.rfc-editor.org/rfc/rfc9112.html#section-2

Usage example: 
```cpp
    // Create an instance of the Response class
    Webserv::Response response;
    response.set_status(200);
    response.set_header("Content-Type", "text/html");
    response.set_body("<html><body>Hello, world!</body></html>");

    // Build the response string
    std::string response_string = response.build_response();
   ```
The `response_string` will be a formatted string, with added content-length header when a body is set
```
HTTP/1.1 200 OK\r\n
Content-Length: 39\r\n
Content-Type: text/html\r\n
\r\n
<html><body>Hello, world!!!!</body></html>
```