### PR TITLE
Feat/request parser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME = webserv
 
-FILES = main.cpp Webserv.cpp
+FILES = main.cpp Webserv.cpp Request.cpp
 
 CXX = c++
 CXXFLAGS = -Wall -Wextra -Werror -std=c++98

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -1,0 +1,248 @@
+#include "Request.hpp"
+
+std::string &trim(std::string &s);
+
+Request::Request(void){};
+
+Request::Request(char *buff)
+{
+	std::istringstream iss(buff);
+
+	try
+	{
+		init_start_line(iss);
+		init_headers(iss);
+		parse_URL();
+	}
+	catch (std::exception const &e)
+	{
+		throw e;
+	}
+};
+
+Request::~Request(void){};
+
+void Request::init_start_line(std::istringstream &iss)
+{
+	std::string row;
+
+	std::getline(iss, row);
+	if (iss.fail())
+	{
+		throw std::runtime_error("parsing request start-line");
+	}
+
+	std::stringstream ss(row);
+	std::string       token;
+
+	ss >> token;
+	if (ss.fail())
+	{
+		throw std::runtime_error("parsing request method");
+	}
+	this->start_line["Method"] = trim(token);
+
+	ss >> token;
+	if (ss.fail())
+	{
+		throw std::runtime_error("parsing request resource");
+	}
+	this->start_line["URL"] = trim(token);
+
+	ss >> token;
+	if (ss.fail())
+	{
+		throw std::runtime_error("parsing request version");
+	}
+	this->start_line["Version"] = trim(token);
+}
+
+void Request::init_headers(std::istringstream &iss)
+{
+	std::string       row;
+	std::string       key;
+	std::string       value;
+	std::stringstream ss;
+
+	while (std::getline(iss, row))
+	{
+		if (iss.fail())
+		{
+			throw std::runtime_error("parsing request header");
+		}
+		if (row.size() == 1)
+		{
+			ss << iss.rdbuf();
+			break;
+		}
+
+		key = std::string(std::strtok((char *) row.c_str(), ":"));
+		value = std::string(row.begin() + row.find(" "), row.end());
+		value = trim(value);
+
+		this->header[key] = value;
+	}
+	if (!iss.eof())
+	{
+		this->body = ss.str();
+	}
+}
+
+std::vector<std::string> Request::get_all_params(void)
+{
+	std::vector<std::string> params;
+	std::stringstream        ss(this->res_query);
+	std::string              token;
+
+	while (std::getline(ss, token, '&'))
+	{
+		if (ss.fail())
+		{
+			throw std::runtime_error("parsing query parameter");
+		}
+		params.push_back(token);
+	}
+
+	return params;
+}
+
+void Request::parse_URL(void)
+{
+	std::string resource = this->start_line["URL"];
+
+	int offset = resource.find("?");
+	if (offset != -1)
+	{
+		this->res_path = resource.substr(0, offset);
+
+		std::string query = resource.substr(offset + 1);
+		int         query_offset = query.find("?");
+		if (query_offset != -1)
+		{
+			query = query.substr(0, query_offset);
+		}
+		this->res_query = query;
+	}
+	else
+	{
+		this->res_path = resource;
+		this->res_query = "";
+	}
+}
+
+// debug
+void Request::display_info(void)
+{
+	std::cout << CYAN "========== START LINE ==========" RES << std::endl;
+	std::map<std::string, std::string> start_line = this->get_start_line();
+	for (std::map<std::string, std::string>::const_iterator it =
+	         start_line.begin();
+	     it != start_line.end(); ++it)
+	{
+		std::cout << GRAY << it->first << RES ": " BLUE << it->second
+		          << RES "\n";
+	}
+
+	std::cout << CYAN "\n===========  HEADER  ===========" RES << std::endl;
+	std::map<std::string, std::string> header = this->get_header();
+	for (std::map<std::string, std::string>::const_iterator it = header.begin();
+	     it != header.end(); ++it)
+	{
+		std::cout << GRAY << it->first << RES ": " BLUE << it->second
+		          << RES "\n";
+	}
+
+	std::cout << CYAN "\n============  BODY  ============" RES << std::endl;
+	std::cout << GREEN << this->get_body() << RES << std::endl;
+
+	std::cout << CYAN "\n============== EXTRA =============" RES << std::endl;
+	std::vector<std::string> params = this->get_all_params();
+	std::cout << GRAY "Path:   " BLUE << this->get_resource_path() << RES
+	          << std::endl;
+	std::cout << GRAY "Params: " BLUE << this->get_resource_query() << RES
+	          << std::endl;
+	for (std::vector<std::string>::const_iterator it = params.begin();
+	     it != params.end(); ++it)
+	{
+		std::cout << YELLOW << *it << RES << std::endl;
+	}
+	std::cout << CYAN "==================================" RES << std::endl;
+}
+
+// getters
+std::map<std::string, std::string> Request::get_start_line(void) const
+{
+	return this->start_line;
+}
+
+std::map<std::string, std::string> Request::get_header(void) const
+{
+	return this->header;
+}
+
+std::string Request::get_body(void) const
+{
+	return this->body;
+}
+
+std::string Request::get_resource_path(void) const
+{
+	return this->res_path;
+}
+
+std::string Request::get_resource_query(void) const
+{
+	return this->res_query;
+}
+
+std::string Request::get_method(void) const
+{
+	std::map<std::string, std::string>::const_iterator it =
+	    this->start_line.find("Method");
+	if (it == this->start_line.end())
+	{
+		return "";
+	}
+	return it->second;
+};
+
+std::string Request::get_url(void) const
+{
+	std::map<std::string, std::string>::const_iterator it =
+	    this->start_line.find("URL");
+	if (it == this->start_line.end())
+	{
+		return "";
+	}
+	return it->second;
+};
+
+std::string Request::get_header_value(std::string const header) const
+{
+	std::map<std::string, std::string>::const_iterator it =
+	    this->start_line.find(header);
+	if (it == this->start_line.end())
+	{
+		return "";
+	}
+	return it->second;
+};
+
+// utils
+static std::string &rtrim(std::string &s, const char *t)
+{
+	s.erase(s.find_last_not_of(t) + 1);
+	return s;
+}
+
+static std::string &ltrim(std::string &s, const char *t)
+{
+	s.erase(0, s.find_first_not_of(t));
+	return s;
+}
+
+std::string &trim(std::string &s)
+{
+	const char *ws = " \t\n\r\f\v";
+	return ltrim(rtrim(s, ws), ws);
+}

--- a/src/Request.hpp
+++ b/src/Request.hpp
@@ -22,30 +22,29 @@ class Request
 {
   private:
 	Request(void);
-	std::map<std::string, std::string> start_line;
+	std::map<std::string, std::string> startLine;
 	std::map<std::string, std::string> header;
 	std::string                        body;
-	std::string                        res_path;
-	std::string                        res_query;
-	void                               init_start_line(std::istringstream &iss);
-	void                               init_headers(std::istringstream &iss);
-	void                               parse_URL(void);
+	std::string                        resourcePath;
+	std::string                        resourceQuery;
+	void                               initStartLine(std::istringstream &iss);
+	void                               initHeaders(std::istringstream &iss);
+	void                               parseURL(void);
 
   public:
-	Request(char *buff);
+	Request(std::string const req);
 	~Request(void);
 
-	std::map<std::string, std::string> get_start_line(void) const;
-	std::map<std::string, std::string> get_header(void) const;
-	std::string                        get_body(void) const;
-	std::string                        get_resource_path(void) const;
-	std::string                        get_resource_query(void) const;
-	std::vector<std::string>           get_all_params(void);
-	std::string                        get_method(void) const;
-	std::string                        get_url(void) const;
-	std::string get_header_value(std::string const header) const;
-
-	void display_info(void);
+	std::map<std::string, std::string> getStartLine(void) const;
+	std::map<std::string, std::string> getHeaders(void) const;
+	std::string                        getBody(void) const;
+	std::string                        getResourcePath(void) const;
+	std::string                        getResourceQuery(void) const;
+	std::vector<std::string>           getAllParams(void) const;
+	std::string                        getMethod(void) const;
+	std::string                        getUrl(void) const;
+	std::string                        getHeaderValue(std::string const) const;
+	void                               displayInfo(void) const;
 };
 
 #endif

--- a/src/Request.hpp
+++ b/src/Request.hpp
@@ -1,0 +1,51 @@
+#ifndef REQUEST_HPP
+#define REQUEST_HPP
+
+#define BLUE "\x1b[38;5;25m"
+#define CYAN "\x1b[38;5;51m"
+#define YELLOW "\x1b[38;5;220m"
+#define PURPLE "\x1b[38;5;162m"
+#define RED "\x1b[38;5;196m"
+#define GRAY "\x1b[38;5;8m"
+#define GREEN "\x1b[38;5;40m"
+#define RES "\x1b[0m"
+
+#include <cstring>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <string.h>
+#include <vector>
+
+class Request
+{
+  private:
+	Request(void);
+	std::map<std::string, std::string> start_line;
+	std::map<std::string, std::string> header;
+	std::string                        body;
+	std::string                        res_path;
+	std::string                        res_query;
+	void                               init_start_line(std::istringstream &iss);
+	void                               init_headers(std::istringstream &iss);
+	void                               parse_URL(void);
+
+  public:
+	Request(char *buff);
+	~Request(void);
+
+	std::map<std::string, std::string> get_start_line(void) const;
+	std::map<std::string, std::string> get_header(void) const;
+	std::string                        get_body(void) const;
+	std::string                        get_resource_path(void) const;
+	std::string                        get_resource_query(void) const;
+	std::vector<std::string>           get_all_params(void);
+	std::string                        get_method(void) const;
+	std::string                        get_url(void) const;
+	std::string get_header_value(std::string const header) const;
+
+	void display_info(void);
+};
+
+#endif

--- a/src/Request_test.cpp
+++ b/src/Request_test.cpp
@@ -1,0 +1,307 @@
+#include "Request.hpp"
+#include "doctest.h"
+
+typedef std::map<std::string, std::string> map;
+
+TEST_CASE("Client start line request")
+{
+	struct s_tt
+	{
+		std::string request;
+		int         expected;
+	} tt[] = {
+	    {"GET / HTTP/1.0\r\n\r\n", 3},
+	    {"GET /path HTTP/1.1\r\n\r\n", 3},
+	    {"GET /path? HTTP/1.1\r\n\r\n", 3},
+	    {"GET /path?query_string HTTP/1.1\r\n\r\n", 3},
+	    {"GET http://localhost/ HTTP/1.1\r\n\r\n", 3},
+	    {"GET http://localhost:8080/ HTTP/1.1\r\n\r\n", 3},
+	    {"GET HTTP/1.1\r\n\r\n", 2},
+	    {"/ HTTP/1.1\r\n\r\n", 2},
+	    {"GET / \r\n\r\n", 2},
+	    {"GET \r\n\r\n", 1},
+	    {"\r\n\r\n", 0},
+	    {"GET		/ HTTP/1.0\r\n\r\n", 3},
+	    {"GET	/	HTTP/1.0\r\n\r\n", 3},
+	    {"GET		/	   	HTTP/1.0		\r\n\r\n", 3},
+	};
+
+	std::size_t n = sizeof(tt) / sizeof(*tt);
+
+	std::size_t i = -1;
+	while (++i < n)
+	{
+		if (tt[i].expected < 3)
+		{
+			CHECK_THROWS_AS(new Request(tt[i].request), std::runtime_error);
+		}
+		else
+		{
+			Request req(tt[i].request);
+			map     requestStartLine = req.getStartLine();
+
+			CHECK_EQ(requestStartLine.size(), tt[i].expected);
+		}
+	}
+}
+
+TEST_CASE("Client request headers")
+{
+	struct s_tt
+	{
+		std::string startLine;
+		std::string headers;
+		int         expected;
+	} tt[] = {
+	    {"GET / HTTP/1.1\r\n", "\r\n", 0},
+	    {"GET / HTTP/1.1\r\n", "h1: foo\r\n\r\n", 1},
+	    {"GET / HTTP/1.1\r\n", "h1: foo\r\nh2: bar\r\n\r\n", 2},
+	    {"GET / HTTP/1.1\r\n", "h1: foo\r\nh2: bar\r\nh3: baz\r\n\r\n", 3},
+	    {"GET / HTTP/1.1\r\n", "h1:foo\r\n h2: bar\r\nh3 : baz\r\n\r\n", 3},
+	    {"GET / HTTP/1.1\r\n",
+	     "h1:foo	 \r\n		h2: bar\r\nh3	 	:			baz	 		"
+	     "\r\n\r\n",
+	     3},
+	    {"GET / HTTP/1.1\r\n", "h1:\r\n\r\n", -1},
+	    {"GET / HTTP/1.1\r\n", "h1\r\n\r\n", -1},
+	    {"GET / HTTP/1.1\r\n", " \r\n\r\n", 0},
+	    {"GET / HTTP/1.1\r\n", "      \r\n\r\n", 0},
+	    {"GET / HTTP/1.1\r\n", "	\r\n\r\n", 0},
+	};
+
+	std::size_t n = sizeof(tt) / sizeof(*tt);
+
+	std::size_t i = -1;
+	while (++i < n)
+	{
+		std::string const request = tt[i].startLine + tt[i].headers;
+
+		if (tt[i].expected == -1)
+		{
+			CHECK_THROWS_AS(new Request(request), std::runtime_error);
+		}
+		else
+		{
+			Request req(request);
+			map     requestHeaders = req.getHeaders();
+
+			CHECK_EQ(requestHeaders.size(), tt[i].expected);
+		}
+	}
+}
+
+TEST_CASE("Client request body")
+{
+	struct s_tt
+	{
+		std::string startLine;
+		std::string headers;
+		std::string body;
+		int         expected;
+	} tt[] = {
+	    {"GET / HTTP/1.1\r\n", "\r\n", "", 0},
+	    {"GET / HTTP/1.1\r\n", "\r\n", "\n", 1},
+	    {"GET / HTTP/1.1\r\n", "\r\n", "foo", 3},
+	    {"GET / HTTP/1.1\r\n", "\r\n", "foo bar baz", 11},
+	    {"GET / HTTP/1.1\r\n", "\r\n", "{\"k\": \"v\"}", 10},
+	    {"GET / HTTP/1.1\r\n", "h1: foo\r\n\r\n",
+	     "{\"k1\": \"v1\", \"k2\": \"v2\"}", 24},
+	};
+
+	std::size_t n = sizeof(tt) / sizeof(*tt);
+
+	std::size_t i = -1;
+	while (++i < n)
+	{
+		std::string const request =
+		    tt[i].startLine + tt[i].headers + tt[i].body;
+		Request           req(request);
+		std::string const requestBody = req.getBody();
+
+		CHECK_EQ(requestBody.size(), tt[i].expected);
+	}
+}
+
+TEST_CASE("getResourcePath")
+{
+	struct s_tt
+	{
+		std::string startLine;
+		std::string expected;
+	} tt[] = {
+	    {"GET / HTTP/1.1\r\n\r\n", "/"},
+	    {"GET /foo HTTP/1.1\r\n\r\n", "/foo"},
+	    {"GET /foo/ HTTP/1.1\r\n\r\n", "/foo/"},
+	    {"GET /foo/bar/baz HTTP/1.1\r\n\r\n", "/foo/bar/baz"},
+	    {"GET /? HTTP/1.1\r\n\r\n", "/"},
+	    {"GET /foo? HTTP/1.1\r\n\r\n", "/foo"},
+	    {"GET /foo/bar?query HTTP/1.1\r\n\r\n", "/foo/bar"},
+	};
+
+	std::size_t n = sizeof(tt) / sizeof(*tt);
+
+	std::size_t i = -1;
+	while (++i < n)
+	{
+		std::string const request = tt[i].startLine;
+		Request           req(request);
+		std::string const requestPath = req.getResourcePath();
+
+		CHECK_EQ(requestPath, tt[i].expected);
+	}
+}
+
+TEST_CASE("getResourceQuery")
+{
+	struct s_tt
+	{
+		std::string startLine;
+		std::string expected;
+	} tt[] = {
+	    {"GET / HTTP/1.1\r\n\r\n", ""},
+	    {"GET /foo HTTP/1.1\r\n\r\n", ""},
+	    {"GET /foo/ HTTP/1.1\r\n\r\n", ""},
+	    {"GET /? HTTP/1.1\r\n\r\n", ""},
+	    {"GET /foo? HTTP/1.1\r\n\r\n", ""},
+	    {"GET /foo/bar?query HTTP/1.1\r\n\r\n", "query"},
+	    {"GET /?arg1=foo&arg2=bar HTTP/1.1\r\n\r\n", "arg1=foo&arg2=bar"},
+	    {"GET /foo?arg1=foo?arg2=bar HTTP/1.1\r\n\r\n", "arg1=foo"},
+	};
+
+	std::size_t n = sizeof(tt) / sizeof(*tt);
+
+	std::size_t i = -1;
+	while (++i < n)
+	{
+		std::string const request = tt[i].startLine;
+		Request           req(request);
+		std::string const requestPath = req.getResourceQuery();
+
+		CHECK_EQ(requestPath, tt[i].expected);
+	}
+}
+
+TEST_CASE("getAllParams")
+{
+	struct s_tt
+	{
+		std::string startLine;
+		int         expected;
+	} tt[] = {
+	    {"GET / HTTP/1.1\r\n\r\n", 0},
+	    {"GET /foo HTTP/1.1\r\n\r\n", 0},
+	    {"GET /? HTTP/1.1\r\n\r\n", 0},
+	    {"GET /foo/bar?query HTTP/1.1\r\n\r\n", 1},
+	    {"GET /?arg1=foo&arg2=bar HTTP/1.1\r\n\r\n", 2},
+	    {"GET /foo?arg1=foo?arg2=bar HTTP/1.1\r\n\r\n", 1},
+	    {"GET /?arg1=foo&arg2=bar&arg3=baz HTTP/1.1\r\n\r\n", 3},
+	};
+
+	std::size_t n = sizeof(tt) / sizeof(*tt);
+
+	std::size_t i = -1;
+	while (++i < n)
+	{
+		std::string const              request = tt[i].startLine;
+		Request                        req(request);
+		std::vector<std::string> const params = req.getAllParams();
+
+		CHECK_EQ(params.size(), tt[i].expected);
+	}
+}
+
+TEST_CASE("getMethod")
+{
+	struct s_tt
+	{
+		std::string startLine;
+		std::string expected;
+	} tt[] = {
+	    {"GET / HTTP/1.1\r\n\r\n", "GET"},
+	    {"POST /foo?a=1&b=2 HTTP/1.1\r\n\r\n", "POST"},
+	    {"DELETE /?id=1 HTTP/1.1\r\n\r\n", "DELETE"},
+	};
+
+	std::size_t n = sizeof(tt) / sizeof(*tt);
+
+	std::size_t i = -1;
+	while (++i < n)
+	{
+		std::string const request = tt[i].startLine;
+		Request           req(request);
+		std::string const method = req.getMethod();
+
+		CHECK_EQ(method, tt[i].expected);
+	}
+}
+
+TEST_CASE("getUrl")
+{
+	struct s_tt
+	{
+		std::string startLine;
+		std::string expected;
+	} tt[] = {
+	    {"GET / HTTP/1.1\r\n\r\n", "/"},
+	    {"POST /foo?a=1&b=2 HTTP/1.1\r\n\r\n", "/foo?a=1&b=2"},
+	    {"DELETE /?id=1 HTTP/1.1\r\n\r\n", "/?id=1"},
+	};
+
+	std::size_t n = sizeof(tt) / sizeof(*tt);
+
+	std::size_t i = -1;
+	while (++i < n)
+	{
+		std::string const request = tt[i].startLine;
+		Request           req(request);
+		std::string const url = req.getUrl();
+
+		CHECK_EQ(url, tt[i].expected);
+	}
+}
+
+TEST_CASE("getHeaderValue")
+{
+	struct s_tt
+	{
+		std::string header;
+		std::string value;
+		std::string expected;
+		bool        expectException;
+	} tt[] = {
+	    {"GET / HTTP/1.1\r\nkey: value\r\n\r\n", "key", "value", false},
+	    {"GET / HTTP/1.1\r\nfoo: 1\r\nbar: 2\r\nbaz: 3\r\n\r\n", "foo", "1",
+	     false},
+	    {"GET / HTTP/1.1\r\nfoo: 1\r\nbar: 2\r\nbaz: 3\r\n\r\n", "bar", "2",
+	     false},
+	    {"GET / HTTP/1.1\r\nfoo: 1\r\nbar: 2\r\nbaz: 3\r\n\r\n", "baz", "3",
+	     false},
+	    {"GET / HTTP/1.1\r\nfoo:1\r\nbar:2\r\nbaz:3\r\n\r\n", "foo", "1",
+	     false},
+	    {"GET / HTTP/1.1\r\nfoo:1\r\nbar:2\r\nbaz:3\r\n\r\n", "baz", "3",
+	     false},
+	    {"GET / HTTP/1.1\r\nfoo:1\r\nbar:2\r\nbaz:3\r\n\r\n", "", "", true},
+	    {"GET / HTTP/1.1\r\nkey: value\r\n\r\n", "foo", "", true},
+	};
+
+	std::size_t n = sizeof(tt) / sizeof(*tt);
+
+	std::size_t i = -1;
+	while (++i < n)
+	{
+		std::string const request = tt[i].header;
+		if (tt[i].expectException)
+		{
+			Request req(request);
+			CHECK_THROWS_AS(req.getHeaderValue(tt[i].value),
+			                std::runtime_error);
+		}
+		else
+		{
+			Request           req(request);
+			std::string const headerValue = req.getHeaderValue(tt[i].value);
+
+			CHECK_EQ(headerValue, tt[i].expected);
+		}
+	}
+}

--- a/src/Webserv.cpp
+++ b/src/Webserv.cpp
@@ -94,16 +94,16 @@ void Webserv::run()
 
 		// --- Request ---
 		char buff[2048];
-		int  bytes_written = recv(client_socket_fd, buff, sizeof(buff), 0);
-		if (bytes_written == -1)
+		int  bytesWritten = recv(client_socket_fd, buff, sizeof(buff), 0);
+		if (bytesWritten == -1)
 		{
 			std::cerr << RED "--- Error: while receiving data" RES << std::endl;
 			perror("Error"); // cant be used...
 			continue;
 		}
-		buff[bytes_written] = 0;
+		buff[bytesWritten] = 0;
 
-		if (bytes_written == 0)
+		if (bytesWritten == 0)
 		{
 			std::cerr << RED "--- Error: client has closed its connection" RES
 			          << std::endl;
@@ -113,13 +113,15 @@ void Webserv::run()
 			          << std::endl;
 			continue;
 		}
-		std::cout << GRAY "Request size: " BLUE << bytes_written << " bytes" RES
+		std::cout << GRAY "Request size: " BLUE << bytesWritten << " bytes" RES
 		          << std::endl;
+
+		std::string const header = buff;
 
 		try
 		{
 			Request req(buff);
-			req.display_info();
+			req.displayInfo();
 		}
 		catch (std::exception const &e)
 		{

--- a/src/Webserv.cpp
+++ b/src/Webserv.cpp
@@ -6,24 +6,29 @@ Webserv::Webserv(int port)
 	server_socket_fd = socket(AF_INET, SOCK_STREAM, 0);
 	if (server_socket_fd < 0)
 	{
-		std::cerr << "ERROR opening socket" << std::endl;
+		std::cerr << RED "--- Error: socket" RES << std::endl;
+		perror("Error"); // cant be used...
 		exit(1);
 	}
-	std::cout << "Server socket created: " << server_socket_fd << std::endl;
+	std::cout << GRAY "Server socket created: " YELLOW << server_socket_fd
+	          << RES << std::endl;
 
 	// --- Associate socket with port ---
 	sockaddr_in server_address = createServerAddress(port);
 	if (bind(server_socket_fd, (struct sockaddr *) &server_address,
 	         sizeof(server_address)) < 0)
 	{
-		std::cerr << "ERROR on binding" << std::endl;
+		std::cerr << RED "--- Error: binding" RES << std::endl;
+		perror("Error"); // cant be used...
+		close(server_socket_fd);
 		exit(1);
 	}
 
 	// --- Set socket to listen for connections ---
 	if (listen(server_socket_fd, 5) < 0)
 	{
-		std::cerr << "ERROR on listen" << std::endl;
+		std::cerr << RED "--- Error: listen" RES << std::endl;
+		perror("Error"); // cant be used...
 		exit(1);
 	}
 }
@@ -39,10 +44,29 @@ int Webserv::getPort()
 	socklen_t   len = sizeof(address);
 	if (getsockname(server_socket_fd, (struct sockaddr *) &address, &len) < 0)
 	{
-		std::cerr << "ERROR on getsockname" << std::endl;
+		std::cerr << RED "--- Error: getsockname" RES << std::endl;
+		perror("Error"); // cant be used...
 		exit(1);
 	}
 	return ntohs(address.sin_port);
+}
+
+void display_initial_connection_msg(int const port_number)
+{
+	std::stringstream ss;
+	std::string       port;
+
+	ss << port_number;
+	if (ss.fail())
+	{
+		std::cerr << RED "--- Error: converting port number" RES << std::endl;
+		perror("Error"); // cant be used...
+		return;
+	}
+
+	port = ss.str();
+	std::cout << BLUE "Waiting new connection in port " CYAN + port << RES
+	          << std::endl;
 }
 
 void Webserv::run()
@@ -52,33 +76,70 @@ void Webserv::run()
 
 	while (true)
 	{
-		// --- Block until client connects and the server accepts the connection
-		// ---
-		std::cout << "Waiting for connection..." << std::endl;
+		display_initial_connection_msg(this->getPort());
+
+		// Block until client connects and the server accepts the connection
 		int client_socket_fd =
 		    accept(server_socket_fd, (struct sockaddr *) &client_addr, &clilen);
 		if (client_socket_fd < 0)
 		{
-			std::cerr << "Error on accept" << std::endl;
+			std::cerr << RED "--- Error: while accepting a new connection" RES
+			          << std::endl;
+			perror("Error"); // cant be used...
 			continue;
 		}
-		std::cout << "Client connected on socket: " << client_socket_fd
+
+		std::cout << GREEN "+++ Client connected in socket: " YELLOW
+		          << client_socket_fd << RES << std::endl;
+
+		// --- Request ---
+		char buff[2048];
+		int  bytes_written = recv(client_socket_fd, buff, sizeof(buff), 0);
+		if (bytes_written == -1)
+		{
+			std::cerr << RED "--- Error: while receiving data" RES << std::endl;
+			perror("Error"); // cant be used...
+			continue;
+		}
+		buff[bytes_written] = 0;
+
+		if (bytes_written == 0)
+		{
+			std::cerr << RED "--- Error: client has closed its connection" RES
+			          << std::endl;
+			perror("Error"); // cant be used...
+			close(client_socket_fd);
+			std::cout << RED "--- Client disconnected from socket: " YELLOW
+			          << std::endl;
+			continue;
+		}
+		std::cout << GRAY "Request size: " BLUE << bytes_written << " bytes" RES
 		          << std::endl;
 
-		// --- Print request ---
-		char buffer[4096];
-		int  n = read(client_socket_fd, buffer, 4096 - 1);
-		buffer[n] = '\0';
-		std::cout << "Received request:\n" << buffer << std::endl;
+		try
+		{
+			Request req(buff);
+			req.display_info();
+		}
+		catch (std::exception const &e)
+		{
+			std::cerr << RED << e.what() << RES << std::endl;
+			close(client_socket_fd);
+			// TODO: handle exception properly...
+			continue;
+		}
 
 		// --- Create response body ---
 		std::string   filename("src/index.html");
 		std::ifstream input_stream(filename.c_str());
 		if (!input_stream.is_open())
 		{
-			std::cerr << "ERROR opening file" << std::endl;
+			std::cerr << RED "--- Error: on open(" CYAN << filename
+			          << RED ")" RES << std::endl;
+			perror("Error"); // cant be used...
 			exit(1);
 		}
+
 		std::stringstream file_content;
 		file_content << input_stream.rdbuf();
 		std::string       body(file_content.str());
@@ -86,14 +147,21 @@ void Webserv::run()
 		body_size << body.length();
 
 		// --- Create response headers ---
-		std::string headers("HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n");
+		std::string headers("HTTP/1.1 200 OK\r\nContent-Type: "
+		                    "text/html\r\nContent-Length: " +
+		                    body_size.str());
 
 		// --- Create response ---
-		std::string response(headers + "Content-Length : " + body_size.str() +
-		                     "\r\n\r\n" + body);
+		std::string response(headers + "\r\n\r\n" + body);
 
 		// --- Send response ---
-		write(client_socket_fd, response.c_str(), response.length());
+		send(client_socket_fd, response.c_str(), response.length(), 0);
+
+		// --- Close client connection ---
+		std::cout << RED "--- Client disconnected from "
+		                 "socket: " YELLOW
+		          << client_socket_fd << RES << std::endl
+		          << std::endl;
 		close(client_socket_fd);
 	}
 }

--- a/src/Webserv.hpp
+++ b/src/Webserv.hpp
@@ -11,13 +11,17 @@
 #include <string>       // to_string
 #include <unistd.h>     // close
 
+#include "Request.hpp"
+
+class Request;
+
 class Webserv
 {
   public:
 	Webserv(int port);
 	~Webserv();
 	void run();
-	int getPort();
+	int  getPort();
 
   private:
 	int         server_socket_fd;

--- a/src/Webserv_test.cpp
+++ b/src/Webserv_test.cpp
@@ -1,22 +1,32 @@
 #include "Webserv.hpp"
 #include "doctest.h"
+#include <sstream>
+#include <streambuf>
 
 TEST_CASE("Webserver")
 {
-    WHEN("Has a specific port number")
-    {
-        Webserv webserver(1337);
-        THEN("The port number is set")
-        {
-            CHECK(webserver.getPort() == 1337);
-        }
-    }
-    WHEN("Has no port number")
-    {
-        Webserv webserver(0);
-        THEN("It uses a random port")
-        {
-            CHECK(webserver.getPort() != 0);
-        }
-    }
+	// redirect std::cout
+	std::streambuf    *oldCoutStreamBuf = std::cout.rdbuf();
+	std::ostringstream oss;
+	std::cout.rdbuf(oss.rdbuf());
+
+	WHEN("Has a specific port number")
+	{
+		Webserv webserver(1337);
+		THEN("The port number is set")
+		{
+			CHECK(webserver.getPort() == 1337);
+		}
+	}
+	WHEN("Has no port number")
+	{
+		Webserv webserver(0);
+		THEN("It uses a random port")
+		{
+			CHECK(webserver.getPort() != 0);
+		}
+	}
+
+	// restore old std::cout
+	std::cout.rdbuf(oldCoutStreamBuf);
 }


### PR DESCRIPTION
### Fora adicionado:
- Mecanismo de parser inicial para as requests
- Algumas validacoes de cabecalho
- Metodos auxiliares para manipulacao de dados do novo objeto `Request` tais como:
   - `getMethod()` -> retorna o metodo utilizado pelo client
   - `geHeaderValue(<headerValue>)` -> retorna o valor do header (`headerValue`) se disponivel
   - Entre outros metodos de uso interno
- Testes unitarios que validam todo corpo da requisicao: _Start Line_, _Header section_, e _Body_ ([rfc9112](https://datatracker.ietf.org/doc/html/rfc9112#name-message-format:~:text=%C2%B6-,2.1.%20Message%20Format,-An%20HTTP/1.1))
- System calls atualizadas, agora `recv/send` sao usados em vez de `read/write`
- Novo objeto `Request` disponivel
- Atualizado testes da classe `Webserv`. O motivo, redirecionar a saida padrao do servidor a fim de nao sujar a saida do teste
- Algumas _ASCII Color codes_ disponiveis

Segue anexo abaixo com imagens do metodo `displayInfo()` da qual exibe as informacoes da requisicao:
![example_webserv_request](https://github.com/erick-medeiros/42sp-webserv/assets/56981089/ae956241-32d8-4c47-9d53-8b201cda23cb)

#### OBS: 
1. Acabei utilizando a funcao `perror`, porem n tenho ctz se eh possivel utiliza-la. De qualquer forma, usei pois ajuda mto a debugar os erros gerados pelas funcoes das libs C++, pois elas se encarregam de providenciar a informacao necessaria.

2. Todas excessoes por hora sao do tipo `runtime_error`, eventualmente pretendo criar excecoes customizadas para tornar o codigo mais semantico. 