### PR TITLE
Feat/cgi

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME = webserv
 
 FILES = main.cpp Server.cpp Response.cpp EpollWrapper.cpp Request.cpp utils.cpp signals.cpp
-FILES += Cookie.cpp
+FILES += Cookie.cpp CGIRequest.cpp
 
 CXX = c++
 CXXFLAGS = -Wall -Wextra -Werror -std=c++98

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,48 @@
+<?php
+
+echo "Hello from PHP script!\n";
+
+echo "SERVER_PROTOCOL: ";
+echo getenv("SERVER_PROTOCOL");
+echo "\n";
+
+echo "SERVER_PORT:     ";
+echo getenv("SERVER_PORT");
+echo "\n";
+
+echo "CONTENT_LENGTH:  ";
+echo getenv("CONTENT_LENGTH");
+echo "\n";
+
+echo "HTTP_HOST:       ";
+echo getenv("HTTP_HOST");
+echo "\n";
+
+echo "HTTP_ACCEPT:     ";
+echo getenv("HTTP_ACCEPT");
+echo "\n";
+
+echo "REQUEST_METHOD:  ";
+echo getenv("REQUEST_METHOD");
+echo "\n";
+
+echo "PATH_INFO:       ";
+echo getenv("PATH_INFO");
+echo "\n";
+
+echo "SCRIPT_NAME:     ";
+echo getenv("SCRIPT_NAME");
+echo "\n";
+
+echo "QUERY_STRING:    ";
+echo getenv("QUERY_STRING");
+echo "\n";
+echo "\n";
+
+$body = $argv[1];
+echo $body;
+echo "\n--------------------------------------\n";
+echo "Request body payload size: ";
+echo strlen($body);
+
+?>

--- a/src/CGIRequest.cpp
+++ b/src/CGIRequest.cpp
@@ -1,0 +1,117 @@
+#include "CGIRequest.hpp"
+
+CGIRequest::CGIRequest(void) {}
+
+CGIRequest::~CGIRequest(void) {}
+
+CGIRequest::CGIRequest(std::string const &resource)
+{
+	this->fileScript = "public" + resource;
+}
+
+bool CGIRequest::isValid(void) const
+{
+	struct stat buff;
+	return (stat(this->fileScript.c_str(), &buff) == 0);
+}
+
+void CGIRequest::exec(Request const &request)
+{
+	prepareCGIRequest(request);
+	executeCGIScript();
+}
+
+void CGIRequest::prepareCGIRequest(Request const &request)
+{
+	initTemporaryDescriptor(request);
+	initScriptArguments(request);
+	initEnviromentVariables(request);
+}
+
+void CGIRequest::initTemporaryDescriptor(Request const &r)
+{
+	std::stringstream ss;
+	ss << r.getFd();
+	std::string const tempFile(CGI_RESPONSE + ss.str());
+	this->fd = open(tempFile.c_str(), O_CREAT | O_RDWR | O_TRUNC, 0644);
+}
+
+void CGIRequest::initScriptArguments(Request const &r)
+{
+	std::vector<std::string> args;
+	args.push_back("php");
+	args.push_back(this->fileScript);
+	args.push_back(r.getBody());
+	this->scriptArgs = createArrayOfStrings(args);
+}
+
+void CGIRequest::initEnviromentVariables(Request const &request)
+{
+	std::vector<std::string> env;
+	env.push_back("SERVER_PORT=8080");
+	env.push_back("SERVER_PROTOCOL=HTTP/1.1");
+	env.push_back(getContentLength(request));
+
+	env.push_back("HTTP_HOST=" + request.getHeaderValue("host"));
+	env.push_back("HTTP_ACCEPT=" + request.getHeaderValue("accept"));
+	env.push_back("REQUEST_METHOD=" + request.getMethod());
+
+	std::string const resource = request.getResourcePath();
+	std::string const scriptName = std::string(resource.begin() + 1, resource.end());
+	env.push_back("PATH_INFO=" + resource);
+	env.push_back("SCRIPT_NAME=" + scriptName);
+
+	if (request.getAllParams().size() > 0)
+	{
+		env.push_back("QUERY_STRING=" + request.getResourceQuery());
+	}
+
+	this->envp = createArrayOfStrings(env);
+}
+
+void CGIRequest::executeCGIScript(void)
+{
+	if (dup2(fd, STDOUT_FILENO) == -1)
+	{
+		throw std::runtime_error("dup2");
+	}
+
+	if (execve("/bin/php", this->scriptArgs, this->envp) == -1)
+	{
+		throw std::runtime_error("execve");
+	}
+}
+
+std::string CGIRequest::getContentLength(Request const &r) const
+{
+	if (r.getBody().size() > 0)
+	{
+		std::string len = r.getHeaderValue("content-length");
+		return "CONTENT_LENGTH=" + len;
+	}
+	return "CONTENT_LENGTH=0";
+}
+
+char **
+CGIRequest::createArrayOfStrings(std::vector<std::string> const &envVars) const
+{
+	char **envp = new char *[envVars.size() + 1];
+
+	for (std::size_t i = 0; i < envVars.size(); ++i)
+	{
+		envp[i] = new char[envVars[i].size() + 1];
+		std::strcpy(envp[i], envVars[i].c_str());
+	}
+	envp[envVars.size()] = NULL;
+
+	return envp;
+}
+
+void CGIRequest::destroyArrayOfStrings(char **envp) const
+{
+	for (char **p = envp; *p; ++p)
+	{
+		delete[] * p;
+	}
+	delete[] envp;
+}

--- a/src/CGIRequest.hpp
+++ b/src/CGIRequest.hpp
@@ -1,0 +1,40 @@
+#ifndef CGIREQUEST_HPP
+#define CGIREQUEST_HPP
+
+#include <fcntl.h>
+#include <iostream>
+#include <sstream>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <vector>
+
+#include "Request.hpp"
+
+class CGIRequest
+{
+  private:
+	char **scriptArgs;
+	char **envp;
+	int    fd;
+
+  public:
+	CGIRequest(void);
+	CGIRequest(std::string const &resource);
+	~CGIRequest(void);
+
+	std::string fileScript;
+
+	bool        isValid(void) const;
+	void        exec(Request const &request);
+	std::string getContentLength(Request const &request) const;
+	void        prepareCGIRequest(Request const &request);
+	void        initTemporaryDescriptor(Request const &request);
+	void        initScriptArguments(Request const &request);
+	void        initEnviromentVariables(Request const &request);
+	void        executeCGIScript(void);
+	char      **createArrayOfStrings(std::vector<std::string> const &envVars) const;
+	void        destroyArrayOfStrings(char **envp) const;
+};
+
+#endif

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -50,7 +50,7 @@ void Request::parseStartLine(std::istringstream &iss)
 	}
 
 	if (!token.empty() && isValidMethod(token))
-		this->startLine["Method"] = trim(token);
+		this->startLine["method"] = trim(token);
 	else
 	{
 		// https://www.rfc-editor.org/rfc/rfc9112#section-3-4
@@ -63,7 +63,7 @@ void Request::parseStartLine(std::istringstream &iss)
 	{
 		throw std::runtime_error("missing request URL");
 	}
-	this->startLine["URL"] = trim(token);
+	this->startLine["url"] = trim(token);
 
 	ss >> token;
 	if (ss.fail())
@@ -72,7 +72,7 @@ void Request::parseStartLine(std::istringstream &iss)
 	}
 	if (isValidHttpVersion(token))
 	{
-		this->startLine["Version"] = trim(token);
+		this->startLine["version"] = trim(token);
 	}
 	else
 	{
@@ -112,6 +112,7 @@ void Request::parseHeaders(std::istringstream &iss)
 			break;
 		}
 		key = row.substr(0, offset);
+		std::transform(key.begin(), key.end(), key.begin(), ::tolower);
 
 		value = std::string(row.begin() + offset + 1, row.end());
 		value = trim(value);
@@ -138,7 +139,7 @@ void Request::parseHeaders(std::istringstream &iss)
 
 void Request::parseURI(void)
 {
-	std::string resource = this->startLine["URL"];
+	std::string resource = this->startLine["url"];
 
 	int offset = resource.find("?");
 	if (offset != -1)
@@ -214,7 +215,7 @@ std::vector<std::string> Request::getAllParams(void) const
 std::string Request::getMethod(void) const
 {
 	std::map<std::string, std::string>::const_iterator it =
-	    this->startLine.find("Method");
+	    this->startLine.find("method");
 	if (it == this->startLine.end())
 	{
 		return "";
@@ -225,7 +226,7 @@ std::string Request::getMethod(void) const
 std::string Request::getUrl(void) const
 {
 	std::map<std::string, std::string>::const_iterator it =
-	    this->startLine.find("URL");
+	    this->startLine.find("url");
 	if (it == this->startLine.end())
 	{
 		return "";

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -1,7 +1,8 @@
 #include "Request.hpp"
 
 Request::Request(int fd)
-    : fd(fd), startLineParsed(false), headersParsed(false), bodyParsed(false){};
+    : fd(fd), startLineParsed(false), headersParsed(false), bodyParsed(false),
+      cgiState(false){};
 
 Request::~Request(void){};
 
@@ -240,7 +241,7 @@ std::string Request::getHeaderValue(std::string const headerValue) const
 	{
 		return it->second;
 	}
-	throw std::runtime_error("request header not found");
+	return "";
 };
 
 bool Request::isValidMethod(std::string const &requestMethod) const
@@ -283,6 +284,16 @@ bool Request::isValidHttpVersion(std::string &requestVersion) const
 	default:
 		return false;
 	}
+}
+
+bool Request::isCgiEnabled(void) const
+{
+	return this->cgiState;
+}
+
+void Request::setCgiAs(bool newState)
+{
+	this->cgiState = newState;
 }
 
 std::ostream &operator<<(std::ostream &os, Request const &req)

--- a/src/Request.hpp
+++ b/src/Request.hpp
@@ -8,9 +8,12 @@
 #include <sstream>
 #include <stdexcept>
 #include <vector>
+#include <bits/stdc++.h>
 
 #include "HttpStatus.hpp"
 #include "utils.hpp"
+
+#define CGI_RESPONSE "/tmp/CGIResponse-"
 
 enum
 {

--- a/src/Request.hpp
+++ b/src/Request.hpp
@@ -44,6 +44,7 @@ class Request
 	bool                               headersParsed;
 	bool                               URIParsed;
 	bool                               bodyParsed;
+	bool                               cgiState;
 
   public:
 	Request(int fd);
@@ -62,6 +63,8 @@ class Request
 	int                                getFd(void) const;
 	bool isValidMethod(std::string const &requestMethod) const;
 	bool isValidHttpVersion(std::string &requestVersion) const;
+	bool isCgiEnabled(void) const;
+	void setCgiAs(bool newState);
 };
 
 std::ostream &operator<<(std::ostream &os, Request const &req);

--- a/src/Request.hpp
+++ b/src/Request.hpp
@@ -1,6 +1,7 @@
 #ifndef REQUEST_HPP
 #define REQUEST_HPP
 
+#include <bits/stdc++.h>
 #include <cstring>
 #include <fstream>
 #include <iostream>
@@ -8,7 +9,6 @@
 #include <sstream>
 #include <stdexcept>
 #include <vector>
-#include <bits/stdc++.h>
 
 #include "HttpStatus.hpp"
 #include "utils.hpp"

--- a/src/Request_test.cpp
+++ b/src/Request_test.cpp
@@ -286,8 +286,8 @@ TEST_CASE("getHeaderValue")
 	    {"GET / HTTP/1.1\r\nfoo: 1\r\nbar: 2\r\nbaz: 3\r\n\r\n", "baz", "3", false},
 	    {"GET / HTTP/1.1\r\nfoo:1\r\nbar:2\r\nbaz:3\r\n\r\n", "foo", "1", false},
 	    {"GET / HTTP/1.1\r\nfoo:1\r\nbar:2\r\nbaz:3\r\n\r\n", "baz", "3", false},
-	    {"GET / HTTP/1.1\r\nfoo:1\r\nbar:2\r\nbaz:3\r\n\r\n", "", "", true},
-	    {"GET / HTTP/1.1\r\nkey: value\r\n\r\n", "foo", "", true},
+	    {"GET / HTTP/1.1\r\nfoo:1\r\nbar:2\r\nbaz:3\r\n\r\n", "", "", false},
+	    {"GET / HTTP/1.1\r\nkey: value\r\n\r\n", "foo", "", false},
 	};
 
 	std::size_t n = sizeof(tt) / sizeof(*tt);

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -37,7 +37,18 @@ void Response::loadFile(const std::string &path)
 Response::Response(const Request &request) : statusCode(200)
 {
 	this->clientFd = request.getFd();
-	parse(request);
+	if (request.isCgiEnabled())
+	{
+		std::stringstream ss;
+		ss << this->clientFd;
+		std::string const tempFile(".temp-" + ss.str());
+		loadFile(tempFile);
+		std::remove(tempFile.c_str());
+	}
+	else
+	{
+		parse(request);
+	}
 }
 
 void Response::parse(const Request &request)
@@ -119,8 +130,8 @@ void Response::prepareMessage()
 	message << CRLF;
 
 	// Optional message body
-	if (body.size() > 0)
-		message << body;
+	if (this->body.size() > 0)
+		message << this->body;
 
 	this->message = message.str();
 }

--- a/src/Response.cpp
+++ b/src/Response.cpp
@@ -41,7 +41,7 @@ Response::Response(const Request &request) : statusCode(200)
 	{
 		std::stringstream ss;
 		ss << this->clientFd;
-		std::string const tempFile(".temp-" + ss.str());
+		std::string const tempFile(CGI_RESPONSE + ss.str());
 		loadFile(tempFile);
 		std::remove(tempFile.c_str());
 	}

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -1,18 +1,5 @@
 #include "Server.hpp"
 
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <unistd.h>
-
-char **createEnvp(std::vector<std::string> const &envVariables);
-
-bool isValidCgiScript(std::string const &filename)
-{
-	struct stat buff;
-	return (stat(filename.c_str(), &buff) == 0);
-}
-
 Server::Server(void) : monitoredSockets(MAX_EVENTS) {}
 
 void Server::init(int argc, char **argv)
@@ -210,78 +197,15 @@ void Server::run()
 
 					if (resource.find_last_of(".php") != std::string::npos)
 					{
-						std::string const fileScript("public" + resource);
-						if (isValidCgiScript(fileScript))
+						CGIRequest cgi(resource);
+						if (cgi.isValid())
 						{
 							request->setCgiAs(true);
 							int status;
 							int pid = fork();
 							if (pid == 0)
 							{
-								std::stringstream ss;
-								ss << request->getFd();
-								std::string const tempFile(".temp-" + ss.str());
-								int               fd = open(tempFile.c_str(),
-								                            O_CREAT | O_RDWR | O_TRUNC, 0644);
-
-								std::vector<std::string> args;
-								args.push_back("php");
-								args.push_back(fileScript);
-								args.push_back(request->getBody());
-								char **scriptArgs = createEnvp(args);
-
-								std::vector<std::string> env;
-								env.push_back("SERVER_PORT=8080");
-								env.push_back("SERVER_PROTOCOL=HTTP/1.1");
-								if (request->getBody().size() > 0)
-								{
-									std::string contentLength;
-									contentLength = request->getHeaderValue("Content"
-									                                        "-"
-									                                        "Lengt"
-									                                        "h");
-									if (contentLength.empty())
-									{
-										contentLength = request->getHeaderValue("con"
-										                                        "ten"
-										                                        "t"
-										                                        "-le"
-										                                        "ngt"
-										                                        "h");
-									}
-									env.push_back(std::string("CONTENT_LENGTH=") +
-									              contentLength);
-								}
-								else
-								{
-									env.push_back("CONTENT_LENGTH=0");
-								}
-								env.push_back(std::string("HTTP_HOST=") +
-								              request->getHeaderValue("Host"));
-								env.push_back(std::string("HTTP_ACCEPT=") +
-								              request->getHeaderValue("Accept"));
-								env.push_back(std::string("REQUEST_METHOD=") +
-								              request->getMethod());
-								env.push_back(std::string("PATH_INFO=") +
-								              request->getResourcePath());
-								env.push_back(std::string("SCRIPT_NAME=") +
-								              std::string(resource.begin() + 1,
-								                          resource.end()));
-
-								if (request->getAllParams().size() > 0)
-								{
-									env.push_back(std::string("QUERY_STRING=") +
-									              request->getResourceQuery());
-								}
-
-								char **envp = createEnvp(env);
-
-								if (dup2(fd, STDOUT_FILENO) == -1)
-								{
-									throw std::runtime_error("dup2");
-								}
-
-								execve("/bin/php", scriptArgs, envp);
+								cgi.exec(*request);
 							}
 							waitpid(pid, &status, 0);
 						}
@@ -345,27 +269,4 @@ sockaddr_in Server::createServerAddress(int port)
 	address.sin_addr.s_addr = INADDR_ANY;
 	address.sin_port = htons(port);
 	return address;
-}
-
-char **createEnvp(std::vector<std::string> const &envVariables)
-{
-	char **envp = new char *[envVariables.size() + 1];
-
-	for (std::size_t i = 0; i < envVariables.size(); ++i)
-	{
-		envp[i] = new char[envVariables[i].size() + 1];
-		std::strcpy(envp[i], envVariables[i].c_str());
-	}
-	envp[envVariables.size()] = NULL;
-
-	return envp;
-}
-
-void destroyEnvp(char **envp)
-{
-	for (char **p = envp; *p; ++p)
-	{
-		delete[] * p;
-	}
-	delete[] envp;
 }

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -11,9 +11,11 @@
 #include <stdexcept>
 #include <stdlib.h> // exit
 #include <string>   // to_string
+#include <sys/wait.h>
 #include <unistd.h> // close
 #include <vector>
 
+#include "CGIRequest.hpp"
 #include "Cookie.hpp"
 #include "EpollWrapper.hpp"
 #include "Request.hpp"


### PR DESCRIPTION
### Adicionado:
- Suporte a CGI
- Mecanismo de criar uma Request CGI (`CGIRequest`) a partir da HTTP Request (objeto `Request`) e prepara todo ambiente basico para processar os scripts via CGI.
- Script em PHP `public/index.php` que processa a Request CGI e exibe as informacoes da request.

### Modificacoes:
- Testes do Reques::getHeaderValue, agora ele retorna uma string vazia caso nao exista o respectivo header. Antes geravamos uma excessao.
- Fora padronizado os headers da HTTP request tambem, agora estao todos em lowercase. Essa mudanca foi necessaria para que, ao definir as variaveis ambientes do CGI, nao precisamos ficar verificando os cases (upper ou lower) dos headers. Facilitando o acesso a informacao.

### Pendente:
- Testes unitarios
- Retornar um 404 caso o script nao exista em `public/`

Abaixo a resposta do CGI qnd acessamos `http://localhost:8080/index.php?foo=123&bar=456`:
![ini2](https://github.com/erick-medeiros/42sp-webserv/assets/56981089/04e85545-3659-4a4a-9431-82f516b53a13)
Note que nao estamos passando o diretorio completo de onde o script se encontra: `public/index.php`. Isso porque por hora, qualqer script em php sera prefixado com `public/`.

Outro detalhe eh a questao do `CONTENT_LENGTH`. De acordo com o [RFC 3875](https://www.rfc-editor.org/rfc/rfc3875#section-1:~:text=%5D.%0A%0A4.1.2.-,CONTENT_LENGTH,-The%20CONTENT_LENGTH%20variable), o content-length passado para o CGI diz respeito ao body da requisicao HTTP.


A seguir, a resposta de execucao do script CGI `public/index.php` passando um body com JSON (seria responsabilidade do script validar esse corpo), o server so se responsabiliza em passar as informacoes necessarias para o script:
![ini](https://github.com/erick-medeiros/42sp-webserv/assets/56981089/d1c4240d-667f-4733-b291-f96ae4c8cb59)
Perceba que fora passado que o content-length do body da requisicao HTTP possui 90 bytes, e por fim o script exibe que fora de fato usados os 90 bytes.
