### PR TITLE
Feat/CGI-Config-update

### DIFF
--- a/cgi-bin/index.php
+++ b/cgi-bin/index.php
@@ -2,39 +2,39 @@
 
 echo "Hello from PHP script!\n";
 
-echo "SERVER_PROTOCOL: ";
+echo "SERVER_PROTOCOL:  ";
 echo getenv("SERVER_PROTOCOL");
 echo "\n";
 
-echo "SERVER_PORT:     ";
+echo "SERVER_PORT:      ";
 echo getenv("SERVER_PORT");
 echo "\n";
 
-echo "CONTENT_LENGTH:  ";
+echo "CONTENT_LENGTH:   ";
 echo getenv("CONTENT_LENGTH");
 echo "\n";
 
-echo "HTTP_HOST:       ";
+echo "HTTP_HOST:        ";
 echo getenv("HTTP_HOST");
 echo "\n";
 
-echo "HTTP_ACCEPT:     ";
+echo "HTTP_ACCEPT:      ";
 echo getenv("HTTP_ACCEPT");
 echo "\n";
 
-echo "REQUEST_METHOD:  ";
+echo "REQUEST_METHOD:   ";
 echo getenv("REQUEST_METHOD");
 echo "\n";
 
-echo "PATH_INFO:       ";
+echo "PATH_INFO:        ";
 echo getenv("PATH_INFO");
 echo "\n";
 
-echo "SCRIPT_NAME:     ";
+echo "SCRIPT_NAME:      ";
 echo getenv("SCRIPT_NAME");
 echo "\n";
 
-echo "QUERY_STRING:    ";
+echo "QUERY_STRING:     ";
 echo getenv("QUERY_STRING");
 echo "\n";
 echo "\n";

--- a/cgi-bin/index.py
+++ b/cgi-bin/index.py
@@ -25,5 +25,5 @@ print()
 
 body = sys.argv[1]
 print(body)
-print("\n--------------------------------------")
+print("--------------------------------------")
 print("Request body payload size: " + str(len(body)))

--- a/config/default.conf
+++ b/config/default.conf
@@ -4,12 +4,12 @@ server {
     error_page 404 pages/error/404.html
     client_max_body_size 1M
 
-    location /test {
-        cgi .php /path
+    location /helloFromPHP {
+        cgi_pass cgi-bin/index.php
     }
 
-    location /test2 {
-        root index.html
+    location /helloFromPython {
+        cgi_pass cgi-bin/index.py
     }
 }
 
@@ -20,6 +20,6 @@ server {
     client_max_body_size 1000K
 
     location /test {
-        cgi .php /path
+        cgi_pass /path
     }
 }

--- a/src/CGIRequest.hpp
+++ b/src/CGIRequest.hpp
@@ -9,7 +9,10 @@
 #include <unistd.h>
 #include <vector>
 
+#include "Connection.hpp"
 #include "Request.hpp"
+
+class Connection;
 
 class CGIRequest
 {
@@ -18,14 +21,17 @@ class CGIRequest
 	char **envp;
 	int    fd;
 
+	void initLocation(std::string const &resource, Connection &connection);
+
   public:
 	CGIRequest(void);
-	CGIRequest(std::string const &resource);
+	CGIRequest(std::string const &resource, Connection &connection);
 	~CGIRequest(void);
 
 	std::string fileScript;
 	std::string script;
 	std::string portNumber;
+	std::string location;
 
 	bool        isValid(void) const;
 	void        exec(Request const &request, int const connectionPortNumber);
@@ -37,7 +43,8 @@ class CGIRequest
 	void        executeCGIScript(void);
 	char      **createArrayOfStrings(std::vector<std::string> const &envVars) const;
 	void        destroyArrayOfStrings(char **envp) const;
-	static bool isValidScript(std::string const &resource);
+	static bool isValidScriptLocation(std::string const &resource,
+	                                  Connection        &connection);
 };
 
 #endif

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -6,7 +6,7 @@
 /*   By: mi <mi@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/10 12:09:40 by eandre-f          #+#    #+#             */
-/*   Updated: 2023/06/11 17:47:25 by mi               ###   ########.fr       */
+/*   Updated: 2023/06/18 16:15:07 by mi               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -38,7 +38,7 @@ int Config::add(string label, string value)
 		return _setDirectoryListing(value);
 	if (label == "location_response_is_dir")
 		return _setResponseIsDir(value);
-	if (label == "location_cgi")
+	if (label == "location_cgi_pass")
 		return _setCGI(value);
 	logError("config label not match: ", label);
 	return 1;
@@ -226,10 +226,8 @@ int Config::_setResponseIsDir(string &value)
 int Config::_setCGI(string &value)
 {
 	stringstream ss(value);
-	string       str;
 	cgi_t        cgi;
 
-	ss >> cgi.extension;
 	ss >> cgi.path;
 
 	if (!ss.eof())

--- a/src/Config.hpp
+++ b/src/Config.hpp
@@ -6,7 +6,7 @@
 /*   By: mi <mi@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/10 12:09:40 by eandre-f          #+#    #+#             */
-/*   Updated: 2023/06/11 17:47:30 by mi               ###   ########.fr       */
+/*   Updated: 2023/06/18 16:15:12 by mi               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -33,7 +33,6 @@ typedef list<pair_string_t>  labels_t;
 typedef struct
 {
 	string path;
-	string extension;
 } cgi_t;
 
 typedef struct

--- a/src/Config_test.cpp
+++ b/src/Config_test.cpp
@@ -6,7 +6,7 @@
 /*   By: mi <mi@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/10 12:09:40 by eandre-f          #+#    #+#             */
-/*   Updated: 2023/06/11 17:50:17 by mi               ###   ########.fr       */
+/*   Updated: 2023/06/18 16:53:42 by mi               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -292,17 +292,16 @@ TEST_SUITE("location")
 		CHECK_EQ(location.response_is_dir, "dir");
 	}
 
-	TEST_CASE("location_cgi")
+	TEST_CASE("location_cgi_pass")
 	{
 		Config config;
 
 		CHECK_EQ(config.add("location", "value"), 0);
 
-		CHECK_EQ(config.add("location_cgi", ".php /bin"), 0);
+		CHECK_EQ(config.add("location_cgi_pass", "/bin"), 0);
 
 		location_t const &location = config.getLocations()[0];
 
-		CHECK_EQ(location.cgi.extension, ".php");
 		CHECK_EQ(location.cgi.path, "/bin");
 
 		SUBCASE("error")
@@ -311,7 +310,7 @@ TEST_SUITE("location")
 
 			CHECK_EQ(config.add("location", "value"), 0);
 
-			CHECK_EQ(config.add("location_cgi", ".php /bin extra"), 1);
+			CHECK_EQ(config.add("location_cgi_pass", "/bin extra"), 1);
 		}
 
 		SUBCASE("multiples")
@@ -319,20 +318,17 @@ TEST_SUITE("location")
 			Config config;
 
 			CHECK_EQ(config.add("location", "first"), 0);
-			CHECK_EQ(config.add("location_cgi", ".php /php"), 0);
+			CHECK_EQ(config.add("location_cgi_pass", "/php"), 0);
 
 			CHECK_EQ(config.add("location", "second"), 0);
-			CHECK_EQ(config.add("location_cgi", ".python /python"), 0);
+			CHECK_EQ(config.add("location_cgi_pass", "/python"), 0);
 
 			CHECK_EQ(config.getLocations().size(), 2);
 
 			location_t const &location_first = config.getLocations()[0];
 			location_t const &location_second = config.getLocations()[1];
 
-			CHECK_EQ(location_first.cgi.extension, ".php");
 			CHECK_EQ(location_first.cgi.path, "/php");
-
-			CHECK_EQ(location_second.cgi.extension, ".python");
 			CHECK_EQ(location_second.cgi.path, "/python");
 		}
 	}

--- a/src/Connection.hpp
+++ b/src/Connection.hpp
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   Connection.hpp                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: eandre-f <eandre-f@student.42sp.org.br>    +#+  +:+       +#+        */
+/*   By: mi <mi@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/16 09:26:18 by eandre-f          #+#    #+#             */
-/*   Updated: 2023/06/16 11:56:19 by eandre-f         ###   ########.fr       */
+/*   Updated: 2023/06/18 15:51:19 by mi               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -17,6 +17,9 @@
 #include "Response.hpp"
 #include "Server.hpp"
 #include <iostream>
+
+class Server;
+class Config;
 
 class Connection
 {

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -104,7 +104,7 @@ Config &Server::getConfig(void)
 	return _config;
 }
 
-int Server::requestClient(Request *request, int const connectionPortNumber)
+int Server::requestClient(Request *request, Connection &connection)
 {
 	std::string rawRequest = getRequestData(request);
 	request->parse(rawRequest);
@@ -114,9 +114,10 @@ int Server::requestClient(Request *request, int const connectionPortNumber)
 	std::string resource = request->getResourcePath();
 	resource = trim(resource);
 
-	if (CGIRequest::isValidScript(resource))
+	if (CGIRequest::isValidScriptLocation(resource, connection))
 	{
-		CGIRequest cgi(resource);
+		CGIRequest cgi(resource, connection);
+
 		if (cgi.isValid())
 		{
 			request->setCgiAs(true);
@@ -124,7 +125,7 @@ int Server::requestClient(Request *request, int const connectionPortNumber)
 			int pid = fork();
 			if (pid == 0)
 			{
-				cgi.exec(*request, connectionPortNumber);
+				cgi.exec(*request, connection.config.getPort());
 			}
 			waitpid(pid, &status, 0);
 		}

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -17,6 +17,7 @@
 
 #include "CGIRequest.hpp"
 #include "Config.hpp"
+#include "Connection.hpp"
 #include "Cookie.hpp"
 #include "EpollWrapper.hpp"
 #include "HttpStatus.hpp"
@@ -26,6 +27,8 @@
 
 #define MAX_EVENTS 500
 #define BLOCK_IND -1
+
+class Connection;
 
 class Server
 {
@@ -40,7 +43,7 @@ class Server
 
 	static int         acceptNewClient(int serverSocket);
 	static std::string getRequestData(Request *request);
-	static int requestClient(Request *request, int const connectionPortNumber);
+	static int         requestClient(Request *request, Connection &connection);
 	static int responseClient(Request *request, Config &config, Cookie &cookies);
 
   private:

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -6,7 +6,7 @@
 /*   By: mi <mi@student.42.fr>                      +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2023/06/16 10:55:41 by eandre-f          #+#    #+#             */
-/*   Updated: 2023/06/17 19:29:37 by mi               ###   ########.fr       */
+/*   Updated: 2023/06/18 15:34:32 by mi               ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -115,7 +115,7 @@ int loop(std::string path_config)
 			{
 				try
 				{
-					Server::requestClient(request, connection->config.getPort());
+					Server::requestClient(request, *connection);
 					if (request->isParsed())
 					{
 						epoll_data_t data = {channel};


### PR DESCRIPTION
## Adicionado:
- O CGI recebe parametros do arquivo de configuracao agora
- Diretiva `cgi_pass` adicionada a estrutura de configuracao

## Como funciona:
Precisamos definir as rotas onde os scripts serao acionados. Para isso, seguindo o modelo do servidor NGINX, defimos o endpoint que acionara o script na diretiva `location`:
```nginx
server {
    # ...
    location /helloFromPHP {
        cgi_pass cgi-bin/index.php
    }

    location /helloFromPython {
        cgi_pass cgi-bin/index.py
    }
}
```
Com isso, quando um cliente fazer uma requisicao para `http://localhost:8080/helloFromPython`, mapeamos o endpoint ao path providenciado na diretiva `cgi_pass`. Com isso conseguimos inserir multiplos scripts e definir seus caminhos de execucao facilmente. 

Importante notar que os parametros continuam funcionando da mesma maneira:
`http://localhost:8080/helloFromPython?foo=123&bar=456`

Outro ponto diz respeito ao metodo da requisicao HTTP. Nao ha a necessidade de providencia-lo explicitamente, pois o metodo eh passado atraves da propria requisicao, eh dever do script gerencia-lo.
