### PR TITLE
Fix error where recv was reading too much

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -76,7 +76,7 @@ std::string Server::getRequestData(Request *request)
 	int  buffSize = 1024;
 	char buff[buffSize];
 
-	int bytesRead = recv(clientSocket, buff, sizeof(buff), 0);
+	int bytesRead = recv(clientSocket, buff, sizeof(buff) - 1, 0);
 
 	if (bytesRead == -1)
 	{


### PR DESCRIPTION
O recv estava lendo o tamanho inteiro do buffer e depois capando o final com `/0` 
Quando o buffer era pequeno tudo certo, mas nos casos que envia uma string maior que o buffer ele estava lendo fora da memória na segunda passada 