### PR TITLE
chunked requests!

### DIFF
--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -34,16 +34,52 @@ void Request::parse(std::string const rawInput, Config const &config)
 
 void Request::parseBody()
 {
+	std::string transferEncoding = getHeaderValue("transfer-encoding");
+
+	if (transferEncoding == "chunked")
+	{
+		size_t            chunkSizeStrPos = unparsed.find("\r\n");
+		std::string       chunkSizeStr = unparsed.substr(0, chunkSizeStrPos);
+		std::stringstream ss(chunkSizeStr);
+		std::size_t       chunkSize = 0;
+		ss >> std::hex >> chunkSize;
+
+		// Wait until we have at least one chunk to parse
+		if (unparsed.size() < chunkSize)
+			return;
+		// Remove the size of the chunk and the \r\n from unparsed
+		unparsed.erase(0, chunkSizeStr.size() + 2);
+		// Append the chunk to the body
+		body.append(unparsed.substr(0, chunkSize));
+		// Remove the chunk from unparsed
+		unparsed.erase(0, chunkSize);
+		// If the unparsed data is the last chunk
+		if (unparsed.find("\r\n0\r\n") == 0 || unparsed.find("0\r\n") == 0)
+		{
+			bodyParsed = true;
+			return;
+		}
+		// If there is a trailing \r\n, remove it for the next chunk
+		if (unparsed.find("\r\n") == 0)
+			unparsed.erase(0, 2);
+		// If there is more data to parse, parse it
+		if (unparsed.size() > 0)
+			parseBody();
+		return;
+	}
+
 	// https://www.rfc-editor.org/rfc/rfc9112.html#section-6-4
 	if (contentLength > 0)
 	{
 		// Wait until unparsed has enough data to parse the body
 		if (unparsed.size() < static_cast<size_t>(contentLength))
 			return;
-
 		body = unparsed.substr(0, contentLength);
 		unparsed.erase(0, contentLength);
+		bodyParsed = true;
+		return;
 	}
+
 	bodyParsed = true;
 }
 

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -121,9 +121,9 @@ int loop(std::string path_config)
 				{
 					std::string rawRequest = Server::getRequestData(connection->fd);
 					connection->request.parse(rawRequest, connection->config);
-					std::cout << connection->request << std::endl;
 					if (connection->request.isParsed())
 					{
+						std::cout << connection->request << std::endl;
 						epoll_data_t data = {channel};
 						epoll.modify(connection->fd, data, EPOLLOUT);
 					}

--- a/tests/integration/cgi/post-chunked-body/config.conf
+++ b/tests/integration/cgi/post-chunked-body/config.conf
@@ -1,0 +1,6 @@
+server {
+    port 9000
+    location / {
+        cgi_pass .py
+    }
+}

--- a/tests/integration/cgi/post-chunked-body/index.py
+++ b/tests/integration/cgi/post-chunked-body/index.py
@@ -1,0 +1,4 @@
+import sys
+
+body = sys.argv[1]
+print(body)

--- a/tests/integration/cgi/post-chunked-body/test.py
+++ b/tests/integration/cgi/post-chunked-body/test.py
@@ -1,0 +1,14 @@
+import unittest
+import requests
+import integration
+
+URL = "http://localhost:9000/index.py"
+
+body = "7\r\nMozilla\r\n12\r\n Developer Network\r\n0\r\n\r\n"
+
+response = integration.post_chunked(URL, body)
+
+assert response.status_code == 200
+
+assert response.text == "Mozilla Developer Network" + "\n"
+

--- a/tests/integration/integration.py
+++ b/tests/integration/integration.py
@@ -34,6 +34,14 @@ def post(URL, body):
         print("Error requests.post: " + URL)
         exit(1)
 
+def post_chunked(URL, body):
+    try:
+        response = requests.post(URL, data=body, headers={"Transfer-Encoding": "chunked"})
+        return response
+    except:
+        print("Error requests.post: " + URL)
+        exit(1)
+
 def delete(URL):
     try:
         response = requests.delete(URL)


### PR DESCRIPTION
Issue #52 

Adiciona maneira de lidar com chunked requests 
Usei o próprio texto de exemplo do MDN no tester -> https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Transfer-Encoding

Dá pra testar via Curl também, ex: 
```sh
echo "Hello world" >test_file 
curl --verbose -H "Transfer-Encoding: chunked" -d @test_file localhost:8080
```

Mas não sei como fazer um exemplo no Tour disso, esse chunked parece algo que por padrão o HTML não faz