### PR TITLE
OS Agnostic: Interface for Linux and Macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ FORMAT = which clang-format >/dev/null 2>&1 \
 all: $(NAME)
 
 run: all
-	./$(NAME) --log-level=DEBUG
+	./$(NAME)
 
 $(NAME): $(OBJ)
 	$(CXX) $(CXXFLAGS) -o $(NAME) $(OBJ)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME = webserv
 
 FILES = main.cpp Server.cpp Response.cpp Request.cpp utils.cpp Cookie.cpp
-FILES += CGIRequest.cpp Config.cpp Connection.cpp loop.cpp Logger.cpp
+FILES += CGIRequest.cpp Config.cpp Connection.cpp loop.cpp Logger.cpp EventWrapper.cpp
 
 ifeq ($(shell uname -s),Linux)
   FILES += EpollWrapper.cpp

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ FORMAT = which clang-format >/dev/null 2>&1 \
 all: $(NAME)
 
 run: all
-	./$(NAME)
+	./$(NAME) --log-level=DEBUG
 
 $(NAME): $(OBJ)
 	$(CXX) $(CXXFLAGS) -o $(NAME) $(OBJ)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,14 @@
 NAME = webserv
 
-FILES = main.cpp Server.cpp Response.cpp EpollWrapper.cpp Request.cpp utils.cpp
-FILES += Cookie.cpp CGIRequest.cpp Config.cpp Connection.cpp loop.cpp Logger.cpp
+FILES = main.cpp Server.cpp Response.cpp Request.cpp utils.cpp Cookie.cpp
+FILES += CGIRequest.cpp Config.cpp Connection.cpp loop.cpp Logger.cpp
+
+ifeq ($(shell uname -s),Linux)
+  FILES += EpollWrapper.cpp
+endif
+ifeq ($(shell uname -s),Darwin)
+  FILES += KqueueWrapper.cpp
+endif
 
 CXX = c++
 CXXFLAGS = -Wall -Wextra -Werror -std=c++98

--- a/src/CGIRequest.cpp
+++ b/src/CGIRequest.cpp
@@ -10,6 +10,14 @@ CGIRequest::CGIRequest(std::string const &resource, Connection &connection)
 {
 	this->fileScript = resource;
 	_fileName = CGI_RESPONSE + utils::to_string(connection.fd);
+
+#ifdef __APPLE__
+	this->scriptPath = "/usr/local/bin/";
+#elif __linux__
+	this->scriptPath = "/usr/bin/";
+#else
+	throw std::runtime_error("Unsupported OS");
+#endif
 }
 
 std::string CGIRequest::exec(void)
@@ -144,7 +152,7 @@ void CGIRequest::executeCGIScript(void)
 		throw std::runtime_error("dup2");
 	}
 
-	std::string const bin = "/usr/local/bin/" + this->script;
+	std::string const bin = this->scriptPath + this->script;
 	if (execve(bin.c_str(), this->scriptArgs, this->envp) == -1)
 	{
 		throw std::runtime_error("execve");

--- a/src/CGIRequest.cpp
+++ b/src/CGIRequest.cpp
@@ -16,7 +16,7 @@ std::string CGIRequest::exec(void)
 {
 	if (access(this->fileScript.c_str(), R_OK) != 0)
 	{
-		log.error("CGI exec: invalid file", strerror(errno));
+		logger.error("CGI exec: invalid file", strerror(errno));
 		return "";
 	}
 
@@ -40,7 +40,7 @@ std::string CGIRequest::exec(void)
 
 	while (max_try > 0)
 	{
-		log.debug("CGI: try: " + utils::to_string(max_try));
+		logger.debug("CGI: try: " + utils::to_string(max_try));
 
 		waitpid(pid, &status, WNOHANG);
 
@@ -181,7 +181,7 @@ void CGIRequest::destroyArrayOfStrings(char **envp) const
 {
 	for (char **p = envp; *p; ++p)
 	{
-		delete[] * p;
+		delete[] *p;
 	}
 	delete[] envp;
 }

--- a/src/CGIRequest.cpp
+++ b/src/CGIRequest.cpp
@@ -144,7 +144,7 @@ void CGIRequest::executeCGIScript(void)
 		throw std::runtime_error("dup2");
 	}
 
-	std::string const bin = "/usr/bin/" + this->script;
+	std::string const bin = "/usr/local/bin/" + this->script;
 	if (execve(bin.c_str(), this->scriptArgs, this->envp) == -1)
 	{
 		throw std::runtime_error("execve");

--- a/src/CGIRequest.hpp
+++ b/src/CGIRequest.hpp
@@ -32,6 +32,7 @@ class CGIRequest
 	std::string portNumber;
 	std::string _fileName;
 	std::string _result;
+	std::string scriptPath;
 	std::string getContentLength() const;
 	void        prepareCGIRequest();
 	void        initTemporaryDescriptor();

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -26,7 +26,7 @@ Config::~Config(void) {}
 
 int Config::add(std::string label, std::string value)
 {
-	log.debug("config: " + label + ": " + value);
+	logger.debug("config: " + label + ": " + value);
 	if (label == "port")
 		return _setPort(value);
 	if (label == "server_name")
@@ -61,7 +61,7 @@ int Config::add(std::string label, std::string value)
 		return _setRequiredCookie(value);
 	if (label == "location_set_cookie")
 		return _setSetCookie(value);
-	log.error("config label not match: " + label);
+	logger.error("config label not match: " + label);
 	return 1;
 }
 
@@ -79,7 +79,7 @@ int Config::_setPort(std::string &value)
 
 	// if (_port != 0)
 	// {
-	// 	log.error("port: exist");
+	// 	logger.error("port: exist");
 	// 	return FAILURE;
 	// }
 
@@ -87,13 +87,13 @@ int Config::_setPort(std::string &value)
 
 	if (port < 1024 || port > 49151)
 	{
-		log.error("port: range invalid");
+		logger.error("port: range invalid");
 		return FAILURE;
 	}
 
 	if (!ss.eof())
 	{
-		log.error("port: error value");
+		logger.error("port: error value");
 		return FAILURE;
 	}
 
@@ -106,12 +106,12 @@ int Config::_setServerName(std::string &value)
 {
 	if (_serverNames.size() > 0)
 	{
-		log.error("server_name: exist");
+		logger.error("server_name: exist");
 		return FAILURE;
 	}
 	if (value == "")
 	{
-		log.error("server_name empty");
+		logger.error("server_name empty");
 		return FAILURE;
 	}
 
@@ -139,7 +139,7 @@ int Config::_setErrorPage(std::string &value)
 
 	if (error < 400 || error > 599)
 	{
-		log.error("error_page: range err: " + value);
+		logger.error("error_page: range err: " + value);
 		return FAILURE;
 	}
 	_errorPage[error] = page;
@@ -197,7 +197,7 @@ int Config::_setHttpMethods(std::string &value)
 		verb = utils::trim(verb);
 		if (!_isValidHttpVerb(verb) || !utils::contains(_allowedMethods, verb))
 		{
-			log.error("invalid method: " + verb);
+			logger.error("invalid method: " + verb);
 			location.http_methods.clear();
 			return 1;
 		}
@@ -549,7 +549,7 @@ std::string Config::readFile(const std::string &filename)
 	}
 	else
 	{
-		log.error("Error: readFile: " + filename);
+		logger.error("Error: readFile: " + filename);
 		return "";
 	}
 
@@ -558,7 +558,7 @@ std::string Config::readFile(const std::string &filename)
 
 static void _panic(std::string err)
 {
-	log.error(err);
+	logger.error(err);
 	throw std::runtime_error("");
 }
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -599,6 +599,10 @@ static std::pair<std::string, std::string> getLabel(std::string &line)
 
 static std::string extractFront(std::list<std::string> &lines)
 {
+	if (lines.empty())
+	{
+		throw std::runtime_error("Cannot extract from an empty list");
+	}
 	std::string str = lines.front();
 	lines.pop_front();
 	return str;

--- a/src/EpollWrapper.cpp
+++ b/src/EpollWrapper.cpp
@@ -23,11 +23,11 @@ EpollWrapper::EpollWrapper(size_t maxevents) : _maxevents(maxevents)
 	memset(events, 0, sizeof(epoll_event) * _maxevents);
 }
 
-int EpollWrapper::add(int fd, epoll_data_t data, uint32_t events)
+int EpollWrapper::add(int fd)
 {
 	struct epoll_event event;
-	event.events = events;
-	event.data = data;
+	event.events = EPOLLIN | EPOLLOUT;
+	event.data.fd = fd;
 	if (epoll_ctl(_epoll_fd, EPOLL_CTL_ADD, fd, &event) == -1)
 	{
 		log.error("epoll_ctl", strerror(errno));
@@ -36,11 +36,11 @@ int EpollWrapper::add(int fd, epoll_data_t data, uint32_t events)
 	return 0;
 }
 
-int EpollWrapper::modify(int fd, epoll_data_t data, uint32_t new_events)
+int EpollWrapper::modify(int fd)
 {
 	struct epoll_event event;
-	event.events = new_events;
-	event.data = data;
+	event.events = EPOLLOUT;
+	event.data.fd = fd;
 	if (epoll_ctl(_epoll_fd, EPOLL_CTL_MOD, fd, &event) == -1)
 	{
 		log.error("epoll_ctl", strerror(errno));

--- a/src/EpollWrapper.cpp
+++ b/src/EpollWrapper.cpp
@@ -46,15 +46,30 @@ int EpollWrapper::remove(int fd)
 	return 0;
 }
 
-std::vector<Event> EpollWrapper::getEvents(int timeout)
+int EpollWrapper::wait(int timeout)
 {
 	int fds = epoll_wait(_epoll_fd, events, _maxevents, timeout);
 	if (fds == -1)
-	{
 		log.error("epoll_wait", strerror(errno));
-		return std::vector<Event>();
+	return fds;
+}
+
+int EpollWrapper::modify(int fd, epoll_data_t data, uint32_t new_events)
+{
+	struct epoll_event event;
+	event.events = new_events;
+	event.data = data;
+	if (epoll_ctl(_epoll_fd, EPOLL_CTL_MOD, fd, &event) == -1)
+	{
+		log.error("epoll_ctl", strerror(errno));
+		return -1;
 	}
-	
+	return 0;
+}
+
+std::vector<Event> EpollWrapper::getEvents(int timeout)
+{
+	int fds = wait(timeout);
 	std::vector<Event> eventsVector;
 	eventsVector.reserve(fds);
 

--- a/src/EpollWrapper.hpp
+++ b/src/EpollWrapper.hpp
@@ -16,6 +16,7 @@
 #include "Config.hpp"
 #include "Logger.hpp"
 #include "Request.hpp"
+#include "EventWrapper.hpp"
 #include <cstddef>
 #include <cstring>
 #include <errno.h>
@@ -24,29 +25,19 @@
 #include <sys/epoll.h>
 #include <unistd.h>
 
-typedef struct
-{
-	enum channel_type_t
-	{
-		CHANNEL_SOCKET,
-		CHANNEL_CONNECTION
-	} type;
-	void *ptr;
-} channel_t;
-
-class EpollWrapper
+class EpollWrapper  : public EventWrapper 
 {
   public:
 	struct epoll_event *events;
 
 	EpollWrapper(size_t maxevents);
-	~EpollWrapper(void);
+	~EpollWrapper();
 
 	int add(int fd);
 	int modify(int fd);
 	int remove(int fd);
 
-	int wait(int timeout);
+	std::vector<Event> getEvents(int timeout);
 
   private:
 	int    _epoll_fd;

--- a/src/EpollWrapper.hpp
+++ b/src/EpollWrapper.hpp
@@ -14,9 +14,9 @@
 #define EPOLLWRAPPER_HPP
 
 #include "Config.hpp"
+#include "EventWrapper.hpp"
 #include "Logger.hpp"
 #include "Request.hpp"
-#include "EventWrapper.hpp"
 #include <cstddef>
 #include <cstring>
 #include <errno.h>
@@ -25,7 +25,7 @@
 #include <sys/epoll.h>
 #include <unistd.h>
 
-class EpollWrapper  : public EventWrapper 
+class EpollWrapper : public EventWrapper
 {
   public:
 	struct epoll_event *events;

--- a/src/EpollWrapper.hpp
+++ b/src/EpollWrapper.hpp
@@ -34,8 +34,9 @@ class EpollWrapper  : public EventWrapper
 	~EpollWrapper();
 
 	int add(int fd);
-	int modify(int fd);
+	int modify(int fd, epoll_data_t data, uint32_t new_events);
 	int remove(int fd);
+	int wait(int timeout);
 
 	std::vector<Event> getEvents(int timeout);
 

--- a/src/EpollWrapper.hpp
+++ b/src/EpollWrapper.hpp
@@ -42,8 +42,8 @@ class EpollWrapper
 	EpollWrapper(size_t maxevents);
 	~EpollWrapper(void);
 
-	int add(int fd, epoll_data_t data, uint32_t events);
-	int modify(int fd, epoll_data_t data, uint32_t new_events);
+	int add(int fd);
+	int modify(int fd);
 	int remove(int fd);
 
 	int wait(int timeout);

--- a/src/EventWrapper.cpp
+++ b/src/EventWrapper.cpp
@@ -4,17 +4,20 @@
 #elif __APPLE__
 #include "KqueueWrapper.hpp"
 #endif
-
+#include <iostream>
 
 class EpollWrapper;
 class KqueueWrapper;
 
-EventWrapper* createEventWrapper() {
+EventWrapper *createEventWrapper()
+{
 #ifdef __linux__
-    return new EpollWrapper(MAX_EVENTS);
+	std::cout << "-- LINUX detected, using Epoll --" << std::endl;
+	return new EpollWrapper(MAX_EVENTS);
 #elif __APPLE__
-    return new KqueueWrapper(MAX_EVENTS);
+	std::cout << "-- APPLE detected, using Kqueue --" << std::endl;
+	return new KqueueWrapper(MAX_EVENTS);
 #else
-    throw std::runtime_error("Unsupported platform");
+	throw std::runtime_error("Unsupported platform");
 #endif
 }

--- a/src/EventWrapper.cpp
+++ b/src/EventWrapper.cpp
@@ -1,0 +1,20 @@
+#include "EventWrapper.hpp"
+#ifdef __linux__
+#include "EpollWrapper.hpp"
+#elif __APPLE__
+#include "KqueueWrapper.hpp"
+#endif
+
+
+class EpollWrapper;
+class KqueueWrapper;
+
+EventWrapper* createEventWrapper() {
+#ifdef __linux__
+    return new EpollWrapper(MAX_EVENTS);
+#elif __APPLE__
+    return new KqueueWrapper(MAX_EVENTS);
+#else
+    throw std::runtime_error("Unsupported platform");
+#endif
+}

--- a/src/EventWrapper.hpp
+++ b/src/EventWrapper.hpp
@@ -1,6 +1,8 @@
 #ifndef EVENT_WRAPPER_H
 #define EVENT_WRAPPER_H
 
+#define MAX_EVENTS 500
+
 #include <vector>
 
 enum EventType
@@ -24,5 +26,7 @@ class EventWrapper
 	virtual int                remove(int fd) = 0;
 	virtual std::vector<Event> getEvents(int timeout) = 0;
 };
+
+EventWrapper *createEventWrapper(void);
 
 #endif // EVENT_WRAPPER_H

--- a/src/EventWrapper.hpp
+++ b/src/EventWrapper.hpp
@@ -1,0 +1,25 @@
+#ifndef EVENT_WRAPPER_H
+#define EVENT_WRAPPER_H
+
+#include <vector>
+
+enum EventType {
+    ERROR_EVENT,
+    READ_EVENT,
+    CLOSE_EVENT
+};
+
+struct Event {
+    int fd;
+    EventType type;
+};
+
+class EventWrapper {
+public:
+    virtual ~EventWrapper() {}
+    virtual int add(int fd) = 0;
+    virtual int remove(int fd) = 0;
+    virtual std::vector<Event> getEvents(int timeout) = 0;
+};
+
+#endif  // EVENT_WRAPPER_H

--- a/src/EventWrapper.hpp
+++ b/src/EventWrapper.hpp
@@ -3,23 +3,26 @@
 
 #include <vector>
 
-enum EventType {
-    ERROR_EVENT,
-    READ_EVENT,
-    CLOSE_EVENT
+enum EventType
+{
+	ERROR_EVENT,
+	READ_EVENT,
+	CLOSE_EVENT
 };
 
-struct Event {
-    int fd;
-    EventType type;
+struct Event
+{
+	int       fd;
+	EventType type;
 };
 
-class EventWrapper {
-public:
-    virtual ~EventWrapper() {}
-    virtual int add(int fd) = 0;
-    virtual int remove(int fd) = 0;
-    virtual std::vector<Event> getEvents(int timeout) = 0;
+class EventWrapper
+{
+  public:
+	virtual ~EventWrapper() {}
+	virtual int                add(int fd) = 0;
+	virtual int                remove(int fd) = 0;
+	virtual std::vector<Event> getEvents(int timeout) = 0;
 };
 
-#endif  // EVENT_WRAPPER_H
+#endif // EVENT_WRAPPER_H

--- a/src/KqueueWrapper.cpp
+++ b/src/KqueueWrapper.cpp
@@ -1,0 +1,82 @@
+#include "KqueueWrapper.hpp"
+#include <iostream>
+#include <sys/event.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+KqueueWrapper::KqueueWrapper(size_t maxevents) : _maxevents(maxevents)
+{
+	_kqueue_fd = kqueue();
+	if (_kqueue_fd == -1)
+	{
+		std::cerr << "Failed to create kqueue" << std::endl;
+	}
+	events = new struct kevent[_maxevents];
+}
+
+KqueueWrapper::~KqueueWrapper()
+{
+	close(_kqueue_fd);
+}
+
+int KqueueWrapper::add(int fd)
+{
+	struct kevent ev;
+	EV_SET(&ev, fd, EVFILT_READ, EV_ADD | EV_ENABLE, 0, 0, NULL);
+	if (kevent(_kqueue_fd, &ev, 1, NULL, 0, NULL) == -1)
+	{
+		return -1;
+	}
+
+	EV_SET(&ev, fd, EVFILT_WRITE, EV_ADD | EV_ENABLE, 0, 0, NULL);
+	return kevent(_kqueue_fd, &ev, 1, NULL, 0, NULL);
+}
+
+int KqueueWrapper::remove(int fd)
+{
+	struct kevent ev;
+	EV_SET(&ev, fd, EVFILT_READ, EV_DELETE, 0, 0, NULL);
+	if (kevent(_kqueue_fd, &ev, 1, NULL, 0, NULL) == -1)
+	{
+		return -1;
+	}
+
+	EV_SET(&ev, fd, EVFILT_WRITE, EV_DELETE, 0, 0, NULL);
+	return kevent(_kqueue_fd, &ev, 1, NULL, 0, NULL);
+}
+
+std::vector<Event> KqueueWrapper::getEvents(int timeout)
+{
+	struct timespec ts;
+	ts.tv_sec = timeout / 1000;
+	ts.tv_nsec = (timeout % 1000) * 1000000;
+
+	int num_events = kevent(_kqueue_fd, NULL, 0, events, 10, &ts);
+	if (num_events == -1)
+	{
+		// Handle error
+		return std::vector<Event>();
+	}
+
+	std::vector<Event> result;
+	result.reserve(num_events);
+
+	for (int i = 0; i < num_events; ++i)
+	{
+		int       fd = events[i].ident;
+		EventType type = ERROR_EVENT;
+
+		if (events[i].filter == EVFILT_READ || events[i].filter == EVFILT_WRITE)
+			type = READ_EVENT;
+		else if (events[i].flags & EV_EOF)
+			type = CLOSE_EVENT;
+
+		Event event;
+		event.fd = fd;
+		event.type = type;
+		result.push_back(event);
+	}
+
+	return result;
+}

--- a/src/KqueueWrapper.hpp
+++ b/src/KqueueWrapper.hpp
@@ -1,0 +1,23 @@
+#ifndef KQUEUE_WRAPPER_H
+#define KQUEUE_WRAPPER_H
+
+#include "EventWrapper.hpp"
+
+class KqueueWrapper : public EventWrapper
+{
+  private:
+	int    _kqueue_fd;
+	size_t _maxevents;
+
+  public:
+	struct kevent *events;
+
+	KqueueWrapper(size_t maxevents);
+	~KqueueWrapper();
+
+	int                add(int fd);
+	int                remove(int fd);
+	std::vector<Event> getEvents(int timeout);
+};
+
+#endif // KQUEUE_WRAPPER_H

--- a/src/Logger.hpp
+++ b/src/Logger.hpp
@@ -62,6 +62,6 @@ class Logger
 };
 
 // global
-static Logger log;
+static Logger logger;
 
 #endif /* LOGGER_HPP */

--- a/src/Logger_test.cpp
+++ b/src/Logger_test.cpp
@@ -127,7 +127,7 @@ TEST_SUITE("Logger extra error")
 		Logger             log(oss);
 		Logger::showColor = false;
 
-		log.error("error", 1);
+		logger.error("error", 1);
 
 		CHECK_EQ(oss.str(), "error: 1\n");
 	}
@@ -138,7 +138,7 @@ TEST_SUITE("Logger extra error")
 		Logger::showColor = false;
 
 		char msg[] = "msg";
-		log.error("error", msg);
+		logger.error("error", msg);
 
 		CHECK_EQ(oss.str(), "error: msg\n");
 	}

--- a/src/Logger_test.cpp
+++ b/src/Logger_test.cpp
@@ -124,7 +124,7 @@ TEST_SUITE("Logger extra error")
 	TEST_CASE("int")
 	{
 		std::ostringstream oss;
-		Logger             log(oss);
+		Logger             logger(oss);
 		Logger::showColor = false;
 
 		logger.error("error", 1);
@@ -134,7 +134,7 @@ TEST_SUITE("Logger extra error")
 	TEST_CASE("char *")
 	{
 		std::ostringstream oss;
-		Logger             log(oss);
+		Logger             logger(oss);
 		Logger::showColor = false;
 
 		char msg[] = "msg";

--- a/src/Request.cpp
+++ b/src/Request.cpp
@@ -24,12 +24,14 @@ void Request::parse(std::string const rawInput, Config const &config)
 		errorCode = HttpStatus::PAYLOAD_TOO_LARGE;
 		return;
 	}
+	logger.debug("Start line parsed");
 	if (!headersParsed)
 	{
 		parseHeaders();
 		if (!headersParsed)
 			return;
 	}
+	logger.debug("Headers parsed");
 	if (!bodyParsed)
 	{
 		parseBody(config);

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -89,6 +89,7 @@ std::string Server::getRequestData(int clientSocket)
 	if (bytesRead == -1)
 	{
 		logger.warning("Error: while receiving data");
+		close(clientSocket);
 		return "";
 	}
 	if (bytesRead == 0)

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -24,8 +24,6 @@
 #include "Request.hpp"
 #include "Response.hpp"
 
-#define MAX_EVENTS 500
-
 class Connection;
 
 class Server

--- a/src/Server.hpp
+++ b/src/Server.hpp
@@ -20,7 +20,6 @@
 #include "Config.hpp"
 #include "Connection.hpp"
 #include "Cookie.hpp"
-#include "EpollWrapper.hpp"
 #include "HttpStatus.hpp"
 #include "Request.hpp"
 #include "Response.hpp"

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -86,7 +86,7 @@ int loop(std::string path_config)
 
 	while (running(true))
 	{
-		std::vector<Event> events = eventWrapper->getEvents(1000);
+		std::vector<Event> events = eventWrapper->getEvents(0);
 
 		for (std::vector<Event>::const_iterator it = events.begin();
 		     it != events.end(); ++it)
@@ -105,6 +105,10 @@ int loop(std::string path_config)
 
 			// Existing connection
 			Connection *connection = connections[fd];
+			// Connection was closed previously in this loop
+			if (!connection)
+				continue;
+
 			if (it->type == ERROR_EVENT || it->type == CLOSE_EVENT)
 			{
 				removeConnection(connection, eventWrapper);
@@ -124,6 +128,7 @@ int loop(std::string path_config)
 						connection->server.handleRequest(*connection);
 						connection->sendHttpResponse();
 						removeConnection(connection, eventWrapper);
+						connections[fd] = NULL;
 					}
 				}
 				catch (std::exception const &e)

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -50,10 +50,11 @@ int loop(std::string path_config)
 	{
 		file = Config::readFile(path_config);
 		configs = Config::parseConfig(file);
+		if (configs.empty())
+			throw std::runtime_error("No server found in config file");
 	}
 	catch (...)
 	{
-		std::cerr << "Error reading config file" << std::endl;
 		return (1);
 	}
 

--- a/src/loop.cpp
+++ b/src/loop.cpp
@@ -17,17 +17,7 @@
 #include "Request.hpp"
 #include "Server.hpp"
 #include <csignal>
-
-// Setup OS-specific event wrapper
-#ifdef __linux__
-#include "EpollWrapper.hpp"
-typedef EpollWrapper PlatformEventWrapper;
-#elif __APPLE__
-#include "KqueueWrapper.hpp"
-typedef KqueueWrapper PlatformEventWrapper;
-#else
-#error Unsupported operating system
-#endif
+#include <typeinfo> // Used to get the name of the event wrapper
 
 bool running(bool status)
 {
@@ -74,7 +64,7 @@ int loop(std::string path_config)
 	std::map<int, Connection *> connections;
 	std::map<int, Server *>     servers;
 	Cookie                      cookies;
-	EventWrapper               *eventWrapper = new PlatformEventWrapper(MAX_EVENTS);
+	EventWrapper               *eventWrapper = createEventWrapper();
 
 	// Setup servers
 	for (size_t i = 0; i < configs.size(); i++)


### PR DESCRIPTION
- Tive que mudar o objeto `log` pra `logger` por que a lib `math` no macos deixa a função `log` como global aí reclama de usar o mesmo nome pra nossa variavel :( 
- Testes todos continuam ✅

`EpollWrapper` e `KqueueWrapper` implementam a mesma interface, que chamei de `EventsWrapper`, que no fim só precisa de 3 funções:
```cpp
class EventWrapper
{
  public:
	virtual ~EventWrapper() {}
	virtual int                add(int fd) = 0;
	virtual int                remove(int fd) = 0;
	virtual std::vector<Event> getEvents(int timeout) = 0;
};
```
Aí quem cria a epoll é a função `createEventsWrapper`, e ela retorna um objeto EventsWrapper que funciona tanto no mac quanto no linux 
```cpp
EventWrapper *createEventWrapper()
{
#ifdef __linux__
	std::cout << "-- LINUX detected, using Epoll --" << std::endl;
	return new EpollWrapper(MAX_EVENTS);
#elif __APPLE__
	std::cout << "-- APPLE detected, using Kqueue --" << std::endl;
	return new KqueueWrapper(MAX_EVENTS);
#else
	throw std::runtime_error("Unsupported platform");
#endif
}
```
Aí no linux continua usando o Epoll
<img width="607" alt="image" src="https://github.com/erick-medeiros/42sp-webserv/assets/26127185/160ff37a-4826-4ff7-b80a-7eacb31db7a5">
E no Mac usa o Kqueue
<img width="627" alt="image" src="https://github.com/erick-medeiros/42sp-webserv/assets/26127185/49cd8665-8f9d-4a4a-ab1e-6be8ab46265f">

